### PR TITLE
Heading level change

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,41 +1,47 @@
 # Active Context
 
 ## Current Focus
-We're implementing a section split feature that allows users to convert a paragraph into a heading and create a new section from it. This enhances the document editing experience by providing a way to better organize content and create new sections as needed.
+We're implementing document structure updates when heading levels change. This includes:
+
+1. When a heading level increases (e.g., H1 → H2), the section moves up in the hierarchy and becomes a child of a section with a lower heading level.
+2. When a heading level decreases (e.g., H2 → H1), the section breaks out of its current container, taking any subsections with higher heading levels with it.
+
+This enhances the document editing experience by maintaining proper hierarchical structure as users modify heading levels.
 
 ## Implementation Approach
-1. Created a ParagraphControls component for the UI
-   - Shows an "H" button when hovering over a paragraph
-   - Uses the floating UI pattern for positioning
-   - Follows the established control component pattern
+1. Added heading level change functionality
+   - Implemented `handleHeadingLevelIncrease` function in collection.svelte.ts
+   - Updated `levelPlugin.ts` to call callbacks when heading levels change
+   - Added callback propagation through the component hierarchy
 
-2. Added section splitting functionality
-   - Implemented `splitSection` function in collection.svelte.ts
-   - Added `addSectionToContainer` function for inserting sections at specific positions
-   - Created specialized addSection callbacks for each section
+2. Implemented document restructuring for heading level increases
+   - Section finds a parent section with the appropriate level
+   - Section moves to become a child of that parent section
+   - Document structure updates to maintain hierarchy
 
-3. Connected components through the hierarchy
-   - Section Container passes specialized addSection functions to each section
-   - Section component handles the splitSection logic
-   - Paragraph component shows controls and triggers the conversion
+3. Planned document restructuring for heading level decreases
+   - Section will break out of its current container
+   - Section will take any subsections with higher heading levels
+   - Document structure will update to maintain hierarchy
 
-4. Created comprehensive documentation
-   - Added guides for creating controls
-   - Added guides for adding new functionality
-   - Documented the component hierarchy pattern
+4. Connected components through the hierarchy
+   - Section Container provides findParentSection and onSectionMoved callbacks
+   - Section component passes these to the Heading component
+   - Heading component triggers the appropriate action when level changes
 
 ## Recent Changes
-- Created ParagraphControls component with an "H" button for converting paragraphs to headings
-- Added addSectionToContainer function to handle inserting sections at specific positions
-- Updated Section Container to pass specialized addSection functions to each section
-- Updated Section component to use the splitSection function
-- Created documentation in guides/creating-controls.md and guides/adding-functionality.md
+- Implemented `handleHeadingLevelIncrease` function in collection.svelte.ts
+- Updated `levelPlugin.ts` to call callbacks when heading levels change
+- Added onLevelIncrease callback to Heading component
+- Updated Section component to handle heading level increases
+- Updated Section Container to provide findParentSection and onSectionMoved callbacks
 
 ## Next Steps
-- Test the section split feature
-- Implement the ability to customize the heading level for the new section
-- Add similar functionality for other content types
-- Enhance the UI with animations for section splitting
+- Implement the heading level decrease functionality
+- Test both heading level increase and decrease functionality
+- Handle edge cases (e.g., first section in a document)
+- Update documentation with the new functionality
+- Consider adding visual indicators for structure changes
 
 ## Active Decisions
 - Using specialized callbacks at each level rather than passing generic ones

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -14,9 +14,10 @@
 - Section splitting functionality
 - Paragraph-to-heading conversion
 - UI controls for content transformation
+- Heading level increase with document restructuring
 
 ## What's Left to Build
-- Customizable heading levels for section splitting
+- Heading level decrease with document restructuring
 - Complete navigation system for all view types
 - Keyboard shortcuts for common operations
 - Additional content transformation capabilities
@@ -29,19 +30,24 @@
 - User permissions and access control
 
 ## Current Status
-We've implemented a section split feature that allows users to convert a paragraph into a heading and create a new section from it. This enhances the document editing experience by providing a way to better organize content and create new sections as needed.
+We've implemented document structure updates when heading levels increase. Now when a user presses Tab or Space at the beginning of a heading, the system will:
 
-The implementation follows a consistent pattern:
+1. Check if there's a parent section with the appropriate level (one level lower than the new heading level)
+2. If found, increase the heading level and move the section to become a child of that parent section
+3. Update the document structure accordingly
+
+The implementation follows the established callback propagation pattern:
 1. Actions are defined in the actions file (collection.svelte.ts)
 2. Callbacks are passed down through the component hierarchy
-3. UI controls trigger the actions
+3. UI events trigger the actions
 4. Everything is connected through the component hierarchy
 
-We've also created comprehensive documentation in the guides folder to document the patterns used in the application, which will make it easier to add new functionality in the future.
+We still need to implement the heading level decrease functionality, which will handle the case when a heading level goes down and needs to break out of its current container, taking any subsections with higher heading levels with it.
 
 ## Known Issues
+- Heading level decrease functionality not yet implemented
+- Edge cases in heading level increase (e.g., first section in a document)
 - Navigation between different view types needs refinement
 - Some edge cases in cursor positioning when navigating between blocks
 - Need to implement navigation for all container types
 - Performance optimization for large documents with many editors
-- Section splitting currently uses the same heading level as the parent section

--- a/src/lib/actions/collection.svelte.ts
+++ b/src/lib/actions/collection.svelte.ts
@@ -119,6 +119,44 @@ export function addSectionToContainer(
 	container.last_modified = new Date().toISOString();
 }
 
+/**
+ * Handles the restructuring when a heading level increases by 1
+ * 
+ * @param section The section whose heading level would increase
+ * @param findParentSection A callback to find a parent section with the appropriate level
+ * @param onSectionMoved A callback to notify when the section has been moved
+ * @returns True if the level change should be allowed, false otherwise
+ */
+export function handleHeadingLevelIncrease(
+	section: Section,
+	findParentSection: (level: number) => Section | null,
+	onSectionMoved: () => void
+): boolean {
+	const currentLevel = section.heading.level;
+	const newLevel = currentLevel + 1;
+	
+	// Find a section with level one less than the new level
+	const parentSection = findParentSection(currentLevel);
+	
+	// If no parent found, prevent the change
+	if (!parentSection) return false;
+	
+	// Increase the heading level
+	section.heading.level = newLevel;
+	
+	// Add the section as a child of the parent section
+	parentSection.children.push(section);
+	
+	// Update timestamps
+	section.heading.last_modified = new Date().toISOString();
+	parentSection.last_modified = new Date().toISOString();
+	
+	// Notify the container that this section has been moved
+	onSectionMoved();
+	
+	return true;
+}
+
 export async function splitSection(
 	node: Section,
 	paragraphId: string,

--- a/src/lib/actions/collection.svelte.ts
+++ b/src/lib/actions/collection.svelte.ts
@@ -121,7 +121,7 @@ export function addSectionToContainer(
 
 /**
  * Handles the restructuring when a heading level increases by 1
- * 
+ *
  * @param section The section whose heading level would increase
  * @param findParentSection A callback to find a parent section with the appropriate level
  * @param onSectionMoved A callback to notify when the section has been moved
@@ -130,30 +130,33 @@ export function addSectionToContainer(
 export function handleHeadingLevelIncrease(
 	section: Section,
 	findParentSection: (level: number) => Section | null,
-	onSectionMoved: () => void
+	onSectionMoved: (sectionId: string) => void
 ): boolean {
 	const currentLevel = section.heading.level;
 	const newLevel = currentLevel + 1;
-	
+
 	// Find a section with level one less than the new level
 	const parentSection = findParentSection(currentLevel);
-	
+
 	// If no parent found, prevent the change
 	if (!parentSection) return false;
-	
+
 	// Increase the heading level
+	console.log('increasing level of section');
 	section.heading.level = newLevel;
-	
+
 	// Add the section as a child of the parent section
+	console.log('adding section to parent section');
 	parentSection.children.push(section);
-	
+
 	// Update timestamps
 	section.heading.last_modified = new Date().toISOString();
 	parentSection.last_modified = new Date().toISOString();
-	
+
 	// Notify the container that this section has been moved
-	onSectionMoved();
-	
+	console.log('notifying container that section has been moved');
+	onSectionMoved(section.id);
+
 	return true;
 }
 

--- a/src/lib/model/examples.ts
+++ b/src/lib/model/examples.ts
@@ -572,7 +572,7 @@ const nestedSectionContainer: (num: number) => z.infer<typeof sectionContainer> 
 		},
 		{ type: 'collection/section-container/tabs', state: { gap: 16, activeIndex: 0 } }
 	],
-	activeView: 'collection/section-container/table-of-contents',
+	activeView: 'collection/section-container/default',
 	children: [
 		nestedSection(num, 1),
 		nestedSection(num, 2),
@@ -677,6 +677,63 @@ export const sectionContainerTOC: Document = {
 			}
 		],
 		activeView: 'collection/section-container/table-of-contents',
+		children: [topLevelSection(1), topLevelSection(2), topLevelSection(3), topLevelSection(4)]
+	}
+};
+
+export const sectionContainerDefault: Document = {
+	state: {
+		mode: 'write',
+		animateNextChange: true
+	},
+	type: 'document',
+	id: 'cdef0123-4567-89ab-cdef-0123456789ab',
+	title: 'Section Container TOC Example',
+	slug: 'section-container-toc-example',
+	created: '2025-02-23T01:04:00Z',
+	last_modified: '2025-02-23T01:04:00Z',
+	content: {
+		type: 'section-container',
+		id: 'd4e5f6a7-b890-1234-5678-9abcdef01234',
+		created: '2025-02-23T01:04:00Z',
+		last_modified: '2025-02-23T01:04:00Z',
+		view: [
+			{ type: 'collection/section-container/default' },
+			{ type: 'collection/section-container/static' },
+			{ type: 'collection/section-container/card', state: { perRow: 3, gap: 4 } },
+			{ type: 'collection/section-container/brick' },
+			{
+				type: 'collection/section-container/table-of-contents',
+				state: {
+					directions: [
+						{
+							type: 'column',
+							gap: 72,
+							interGenerationGap: 32,
+							innerGap: 4,
+							innerDirection: 'column'
+						},
+						{
+							type: 'row',
+							perRow: 3,
+							gap: 16,
+							interGenerationGap: 16,
+							innerGap: 16,
+							innerDirection: 'column'
+						}
+					]
+				}
+			},
+			{
+				type: 'collection/section-container/sidebar',
+				state: { percentageWidth: 30, activeIndex: 1 }
+			},
+			{
+				type: 'collection/section-container/tabs',
+				state: { gap: 16, activeIndex: 0 }
+			}
+		],
+		activeView: 'collection/section-container/default',
 		children: [topLevelSection(1), topLevelSection(2), topLevelSection(3), topLevelSection(4)]
 	}
 };

--- a/src/lib/services/editorFocus.ts
+++ b/src/lib/services/editorFocus.ts
@@ -17,26 +17,20 @@ export const EditorFocusService = (() => {
 
 	// Return the public API
 	return {
-		// Register an editor
 		register(id: string, view: EditorView) {
-			console.log(`Registering editor for ${id}`);
 			editors.set(id, view);
 		},
 
-		// Unregister an editor
 		unregister(id: string) {
-			console.log(`Unregistering editor for ${id}`);
 			editors.delete(id);
 		},
 
 		// Update an existing editor view
 		updateView(id: string, view: EditorView) {
 			if (editors.has(id)) {
-				console.log(`Updating view for ${id}`);
 				editors.set(id, view);
 				return true;
 			}
-			console.log(`Cannot update view for ${id} - not found`);
 			return false;
 		},
 
@@ -44,26 +38,21 @@ export const EditorFocusService = (() => {
 		focus(id: string, documentNode: Document, cursorPosition: CursorPosition = 'start') {
 			const view = editors.get(id);
 			if (!view) {
-				console.log(`View not found for ${id}`);
 				return false;
 			}
 
-			console.log(`View found for ${id}`);
 
 			try {
 				// Check if the DOM element is still in the document
 				if (!isElementInDocument(view.dom as HTMLElement)) {
-					console.error(`Editor DOM for ${id} is not in the document`);
 					return false;
 				}
 
 				// Update the document's focusedContentId
 				documentNode.state.focusedContentId = id;
-				console.log(`Set focusedContentId to ${id}`);
 
 				// Focus the editor
 				view.focus();
-				console.log(`Focused ${id}`);
 
 				// Set cursor position
 				const { state } = view;

--- a/src/lib/view/collection/section-container/Default/Default.svelte
+++ b/src/lib/view/collection/section-container/Default/Default.svelte
@@ -23,6 +23,8 @@
 				refs: Refs;
 				onUnmount: () => void;
 				addSection: (section: Section) => void;
+				findParentSection: (level: number) => Section | null;
+				onSectionMoved: () => void;
 			}>
 		}))
 	);
@@ -31,14 +33,30 @@
 <div class="flex flex-col gap-12">
 	{console.log('children renderers length in section container: ', ChildrenRenderers.length)}
 	{#each ChildrenRenderers as { Renderer }, index}
-		<Renderer
-			node={node.children[index]}
-			{refs}
-			{onUnmount}
-			addSection={(section) => {
-				onUnmount();
-				addSectionToContainer(node, section, index + 1);
-			}}
-		/>
+			<Renderer
+				node={node.children[index]}
+				{refs}
+				{onUnmount}
+				addSection={(section) => {
+					onUnmount();
+					addSectionToContainer(node, section, index + 1);
+				}}
+				findParentSection={(level) => {
+					// Look for a section before the current one with the specified level
+					for (let i = index - 1; i >= 0; i--) {
+						if (node.children[i].heading.level === level) {
+							return node.children[i];
+						}
+					}
+
+					console.log('no parent section found for level: ', level);
+					return null;
+				}}
+				onSectionMoved={() => {
+					// Remove the section from the container
+					node.children.splice(index, 1);
+					node.last_modified = new Date().toISOString();
+				}}
+			/>
 	{/each}
 </div>

--- a/src/lib/view/collection/section-container/Default/Default.svelte
+++ b/src/lib/view/collection/section-container/Default/Default.svelte
@@ -2,7 +2,7 @@
 	import type { Refs } from '$lib/components/Document.svelte';
 	import { type Section, type SectionContainer } from '$lib/model/collection';
 	import { registry } from '$lib/viewRegistry.svelte';
-	import { tick, type Component } from 'svelte';
+	import { onMount, tick, type Component } from 'svelte';
 	import { addSectionToContainer } from '$lib/actions/collection.svelte';
 
 	let {
@@ -15,7 +15,8 @@
 		onUnmount: () => void;
 	} = $props();
 	let { children } = $derived(node);
-    let sectionsToRemove = $state<string[]>([]);
+	let sectionsToRemove = $state<string[]>([]);
+	let shouldRemoveSections = $derived(sectionsToRemove.length > 0);
 
 	let ChildrenRenderers = $derived(
 		children.map((child) => ({
@@ -25,46 +26,54 @@
 				onUnmount: () => void;
 				addSection: (section: Section) => void;
 				findParentSection: (level: number) => Section | null;
-				onSectionMoved: () => void;
+				onSectionMoved: (sectionId: string) => void;
 			}>
 		}))
 	);
+	onMount(() => {
+		console.log('mounted');
+	});
 
-    $effect(() => {
-        if (sectionsToRemove.length > 0) {
-            console.log("sections to remove: ", sectionsToRemove);
-            node.children = node.children.filter(child => !sectionsToRemove.includes(child.id));
-            sectionsToRemove = [];
-        }
-    });
+	$effect(() => {
+		console.log('in effect for: ', node.id, sectionsToRemove);
+		if (shouldRemoveSections) {
+			console.log('sections to remove: ', sectionsToRemove);
+			node.children = node.children.filter((child) => !sectionsToRemove.includes(child.id));
+			sectionsToRemove = [];
+		}
+	});
+
+	$inspect(node.id, sectionsToRemove, node.children.map((child) => child.id), shouldRemoveSections);
+
+
 </script>
 
 <div class="flex flex-col gap-12">
 	{#each ChildrenRenderers as { Renderer }, index (node.children[index].id + node.children[index].last_modified)}
-			<Renderer
-				node={node.children[index]}
-				{refs}
-				{onUnmount}
-				addSection={(section) => {
-					onUnmount();
-					addSectionToContainer(node, section, index + 1);
-				}}
-				findParentSection={(level) => {
-					// Look for a section before the current one with the specified level
-					for (let i = index - 1; i >= 0; i--) {
-						if (node.children[i].heading.level === level) {
-							return node.children[i];
-						}
+		<Renderer
+			node={node.children[index]}
+			{refs}
+			{onUnmount}
+			addSection={(section) => {
+				onUnmount();
+				addSectionToContainer(node, section, index + 1);
+			}}
+			findParentSection={(level) => {
+				// Look for a section before the current one with the specified level
+				for (let i = index - 1; i >= 0; i--) {
+					if (node.children[i].heading.level === level) {
+						return node.children[i];
 					}
+				}
 
-					console.log('no parent section found for level: ', level);
-					return null;
-				}}
-				onSectionMoved={async () => {
-					sectionsToRemove.push(node.children[index].id);
-					node.last_modified = new Date().toISOString();
-					console.log("sucked section removed from container");
-				}}
-			/>
+				console.log('no parent section found for level: ', level);
+				return null;
+			}}
+			onSectionMoved={(sectionId) => {
+				// node.last_modified = new Date().toISOString();
+				sectionsToRemove.push(sectionId);
+				console.log('sucked section removed from container');
+			}}
+		/>
 	{/each}
 </div>

--- a/src/lib/view/collection/section/default/Default.svelte
+++ b/src/lib/view/collection/section/default/Default.svelte
@@ -69,9 +69,10 @@
 	let controlElement: HTMLDivElement | null = $state(null);
 	let containerElement: HTMLDivElement | null = $state(null);
 
-	$inspect(node);
-	$inspect(node?.summary);
-	$inspect(node?.heading);
+    $effect(() => {
+        console.log("detected change in children of section: ", node.children);
+    });
+
 
 	onMount(() => {
 		if (containerElement && controlElement) {
@@ -109,18 +110,18 @@
 					bind:node={node.heading} 
 					{refs} 
 					{onUnmount}
-					onLevelIncrease={() => handleHeadingLevelIncrease(node, findParentSection, onSectionMoved)} 
+					onLevelIncrease={() => {
+                        console.log("onLevelIncrease in section");
+                        return handleHeadingLevelIncrease(node, findParentSection, onSectionMoved)}} 
 				/>
 			</div>
 		{/key}
 	{/if}
 
-	<div bind:this={contentElement}>
+	<div bind:this={contentElement} class="flex flex-col gap-7">
 		{#if (node.view[viewStateIndex] as ViewState).state === 'expanded'}
-            {console.log("children renderers length in section: ", ChildrenRenderers.length)}
 			<!-- should work without the key, but not working -->
 			{#each ChildrenRenderers as { Renderer }, i (node.children[i].last_modified + node.children[i].id)}
-				{console.log("node.children[i].id: ", node.children[i].id)}
 				<Renderer
 					bind:node={node.children[i]}
 					onSplit={(newBlocks) => {

--- a/src/lib/view/collection/section/default/Default.svelte
+++ b/src/lib/view/collection/section/default/Default.svelte
@@ -7,7 +7,7 @@
 	import { registry } from '$lib/viewRegistry.svelte';
 	import { getContext, onMount, type Component } from 'svelte';
 	import DefaultControl from './control/DefaultControl.svelte';
-	import { splitParagraph, splitSection } from '$lib/actions/collection.svelte';
+	import { splitParagraph, splitSection, handleHeadingLevelIncrease } from '$lib/actions/collection.svelte';
 
 	type Props = {
 		node: Section;
@@ -15,6 +15,8 @@
 		onUnmount: () => void;
 		overRides: { heading: boolean };
 		addSection: (newSection: Section) => void;
+		findParentSection: (level: number) => Section | null;
+		onSectionMoved: () => void;
 	};
 	type ViewState = { state: 'expanded' | 'summary' | 'collapsed' };
 	let {
@@ -22,7 +24,9 @@
 		refs,
 		onUnmount,
 		overRides = { heading: true },
-		addSection
+		addSection,
+		findParentSection,
+		onSectionMoved
 	}: Props = $props();
 
 	let document = getContext('document') as Document;
@@ -33,6 +37,7 @@
 			node: ContentHeading;
 			refs: Refs;
 			onUnmount: () => void;
+			onLevelIncrease: () => boolean;
 		}>
 	);
 	let ChildrenRenderers = $derived(
@@ -100,7 +105,12 @@
 	{#if overRides && overRides.heading}
 		{#key node.heading.id}
 			<div bind:this={headingElement}>
-				<HeadingRenderer bind:node={node.heading} {refs} {onUnmount} />
+				<HeadingRenderer 
+					bind:node={node.heading} 
+					{refs} 
+					{onUnmount}
+					onLevelIncrease={() => handleHeadingLevelIncrease(node, findParentSection, onSectionMoved)} 
+				/>
 			</div>
 		{/key}
 	{/if}

--- a/src/lib/view/collection/section/default/Default.svelte
+++ b/src/lib/view/collection/section/default/Default.svelte
@@ -122,6 +122,7 @@
 		{#if (node.view[viewStateIndex] as ViewState).state === 'expanded'}
 			<!-- should work without the key, but not working -->
 			{#each ChildrenRenderers as { Renderer }, i (node.children[i].last_modified + node.children[i].id)}
+            <div class={node.children[i].type === 'section-container' ? 'mt-5' : ''}>
 				<Renderer
 					bind:node={node.children[i]}
 					onSplit={(newBlocks) => {
@@ -135,6 +136,7 @@
 					{refs}
 					{onUnmount}
 				/>
+            </div>
 			{/each}
 		{:else if (node.view[viewStateIndex] as ViewState).state === 'summary'}
 			{#each SummaryRenderers as { Renderer }, i (node.summary[i].last_modified + node.summary[i].id)}

--- a/src/lib/view/content/heading/Heading.svelte
+++ b/src/lib/view/content/heading/Heading.svelte
@@ -10,7 +10,7 @@
 	import { EditorFocusService } from '$lib/services/editorFocus';
 	import type { NavigationHandler } from '$lib/services/navigation/types';
 	import { createNavigationPlugin } from './navigationPlugin';
-import { createLevelPlugin } from './levelPlugin';
+	import { createLevelPlugin } from './levelPlugin';
 
 	let documentNode: Document = getContext('document');
 
@@ -38,6 +38,7 @@ import { createLevelPlugin } from './levelPlugin';
 		additionalFlipId?: string;
 		getNextEditable: NavigationHandler;
 		getPrevEditable: NavigationHandler;
+		onLevelIncrease: () => boolean;
 	};
 
 	let {
@@ -47,7 +48,8 @@ import { createLevelPlugin } from './levelPlugin';
 		updateParent,
 		additionalFlipId,
 		getNextEditable,
-		getPrevEditable
+		getPrevEditable,
+		onLevelIncrease
 	}: Props = $props();
 	let { content, level } = $derived(node);
 
@@ -55,7 +57,7 @@ import { createLevelPlugin } from './levelPlugin';
 	let headingSize = $derived(getHeadingSize(level));
 
 	let doc: Node = $derived(defaultMarkdownParser.parse(headingContent));
-	
+
 // Create the plugins array
 const plugins = [
 	...exampleSetup({
@@ -63,17 +65,16 @@ const plugins = [
 		menuBar: false
 	}),
     createNavigationPlugin(getNextEditable, getPrevEditable, documentNode),
-    createLevelPlugin(node, documentNode)
+    createLevelPlugin(node, documentNode, onLevelIncrease)
 ];
-	
-	
+
 	// Create the editor state
 	let editorState = EditorState.create({
 		schema,
 		doc: defaultMarkdownParser.parse(headingContent),
 		plugins
 	});
-	
+
 	// Update editor state when content changes
 	$effect(() => {
 		const newDoc = defaultMarkdownParser.parse(`# ${content}`);
@@ -127,7 +128,7 @@ const plugins = [
 
 		// Register this editor with the EditorFocusService
 		EditorFocusService.register(node.id, view);
-		
+
 		$effect(() => {
 			if (documentNode.state.mode !== 'read') {
 				// When not in read mode, set up the mouseenter handler after a delay
@@ -140,9 +141,14 @@ const plugins = [
 				}, 800);
 
 				const timeoutId2 = setTimeout(() => {
-					view.setProps({ editable: () => {
-						return documentNode.state.focusedContentId === node.id && documentNode.state.mode !== 'read';
-					} });
+					view.setProps({
+						editable: () => {
+							return (
+								documentNode.state.focusedContentId === node.id &&
+								documentNode.state.mode !== 'read'
+							);
+						}
+					});
 				}, 800);
 
 				// Return cleanup function to clear timeout if effect reruns
@@ -158,7 +164,7 @@ const plugins = [
 		});
 
 		return () => {
-			if (view) {
+			if (view && node) {
 				// Unregister this editor when it's destroyed
 				EditorFocusService.unregister(node.id);
 				view.destroy();
@@ -170,9 +176,9 @@ const plugins = [
 <div
 	bind:this={ref}
 	onclick={(e) => {
-        if (documentNode.state.mode !== 'read') {
-            e.stopPropagation();
-        }
+		if (documentNode.state.mode !== 'read') {
+			e.stopPropagation();
+		}
 	}}
 	class={[headingSize, 'prose-h1:inline-block', 'prose-h1:font-semibold']}
 ></div>

--- a/src/lib/view/content/heading/Heading.svelte
+++ b/src/lib/view/content/heading/Heading.svelte
@@ -107,8 +107,6 @@ const plugins = [
 					const dom = document.createElement('h1');
 					dom.setAttribute('data-flip-id', id);
 
-					console.log("yo I'm in the heading node view for: " + content + ' with id: ' + id);
-
 					refs[id] = { element: dom, animateAbsolute: false, animateNested: false };
 
 					return {

--- a/src/lib/view/content/paragraph/Paragraph.svelte
+++ b/src/lib/view/content/paragraph/Paragraph.svelte
@@ -83,7 +83,6 @@
 	let ref: HTMLDivElement;
 
 	onMount(() => {
-		console.log('I just got mounted baybeh for ' + content);
 		view = new EditorView(ref, {
 			state: editorState,
 			nodeViews: {
@@ -187,7 +186,7 @@
 			e.stopPropagation();
 		}
 	}}
-	class="mt-6 leading-7 first:mt-0 relative"
+	class="leading-7 relative"
 	bind:this={ref}
 	onmouseenter={() => isParagraphHovered = true}
 	onmouseleave={() => isParagraphHovered = false}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
 		card,
 		nestedSummary,
 		sectionContainerTOC,
+        sectionContainerDefault,
 		sectionContainerTOCCard,
 		sidebarExample
 	} from '$lib/model/examples';
@@ -36,7 +37,7 @@
 		}
 	});
 
-	let node = $state(sectionContainerTOC as DocumentType);
+	let node = $state(sectionContainerDefault as DocumentType);
 	let isPublishing = $state(false);
 	let publishStatus = $state<{ success: boolean; message: string; documentId?: string } | null>(
 		null


### PR DESCRIPTION
This PR makes it so that if you if you increase the level of a heading, it gets swallowed by its above neighbor.

So if you have something like

H1

H1

H1


and then you increase the level of the middle H1 to H2, it gets consumed to the section headed by H1.

There are some caveats too, in which I am not sure what happens if we have:

H1

H1        <-      if we increment this one,

H2       <-      what will happen to this one

H1

I also disabled the node last_modified update because it interfered with svelte's update based on reactivity, it made the update wrong
