### PR TITLE
change the update system of document

### DIFF
--- a/src/lib/actions/collection/section.svelte.ts
+++ b/src/lib/actions/collection/section.svelte.ts
@@ -121,8 +121,10 @@ export function handleHeadingLevelIncrease(
 export async function splitSection(
 	node: Section,
 	paragraphId: string,
+	document: Document,
 	addSection: (section: Section) => void
 ) {
+    document.state.animateNextChange = false;
 	const newId = crypto.randomUUID();
 
 	// find the paragraph in chilren section's content, and then remove the children from everything below that

--- a/src/lib/components/Document.svelte
+++ b/src/lib/components/Document.svelte
@@ -6,6 +6,8 @@
 	import { gsap } from 'gsap';
 	import Flip from 'gsap/dist/Flip';
 	import type { NoHeadingContentSingle } from '../model/collection';
+	import { createDocumentManipulator } from '../documentManipulator.svelte';
+
 	gsap.registerPlugin(Flip);
 
 	export type Refs = Record<
@@ -14,17 +16,18 @@
 	>;
 
 	let { node }: { node: Document } = $props();
-    setContext('document', node);
+	const documentManipulator = createDocumentManipulator(node);
+	setContext('document', node);
+	setContext('documentManipulator', documentManipulator);
+
 	let Renderer = $derived(
 		registry[node.content.activeView as keyof typeof registry] as Component<{
-			node: NoHeadingContentSingle;
+			path: (string | number)[];
 			refs: Refs;
 			onUnmount: () => void;
 		}>
 	);
 	let refs = $state<Refs>({});
-
-	setContext('document', node);
 
 	let flipState: Flip.FlipState | null = $state(null);
 
@@ -107,6 +110,6 @@
 
 <div class="flex flex-col items-center gap-4">
 	<div class=" w-2/3">
-		<Renderer bind:node={node.content} {refs} {onUnmount} />
+		<Renderer path={['content']} {refs} {onUnmount} />
 	</div>
 </div>

--- a/src/lib/documentManipulator.svelte.ts
+++ b/src/lib/documentManipulator.svelte.ts
@@ -1,0 +1,23 @@
+import type { Document } from '$lib/model/document';
+
+export function createDocumentManipulator(state: Document) {
+	const document = $state(state);
+
+	function getByPath(path: (string | number)[]) {
+		let curr = document as object;
+
+		for (const chunk of path) {
+			if (curr) {
+				curr = curr[chunk as keyof typeof curr];
+			} else {
+				console.log('curr is undefined');
+			}
+		}
+
+		return curr;
+	}
+
+	return { getByPath };
+}
+
+export type DocumentManipulator = ReturnType<typeof createDocumentManipulator>;

--- a/src/lib/model/examples.ts
+++ b/src/lib/model/examples.ts
@@ -174,8 +174,6 @@ export const nested: Document = {
 	}
 };
 
-    
-
 /**
  * a document with one section, one paragraph child, one paragraph summary
  */
@@ -235,7 +233,6 @@ export const nestedSummary: Document = {
 		]
 	}
 };
-
 
 /**
  * a document with one untitled section, a paragraph child and section child, one untitled section child

--- a/src/lib/view/collection/section-container/Card/Controls.svelte
+++ b/src/lib/view/collection/section-container/Card/Controls.svelte
@@ -1,16 +1,21 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, getContext } from 'svelte';
 	import { float } from '$lib/view/utils/float.svelte';
+	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
+	import type { SectionContainer } from '$lib/model/collection';
 
 	let {
-		node,
+		path,
 		onUnmount,
 		isCardHovered
 	}: {
-		node: any;
+		path: (string | number)[];
 		onUnmount: () => void;
 		isCardHovered: boolean;
 	} = $props();
+
+	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
+	const node = documentManipulator.getByPath(path) as SectionContainer;
 
 	let isHovered = $state(false);
 

--- a/src/lib/view/collection/section-container/Default/Default.svelte
+++ b/src/lib/view/collection/section-container/Default/Default.svelte
@@ -2,80 +2,64 @@
 	import type { Refs } from '$lib/components/Document.svelte';
 	import { type Section, type SectionContainer } from '$lib/model/collection';
 	import { registry } from '$lib/viewRegistry.svelte';
-	import { onMount, tick, type Component } from 'svelte';
-	import {
-		addSectionToContainer,
-		removeSectionFromContainer
-	} from '$lib/actions/collection/section-container.svelte';
+	import type { Component } from 'svelte';
+	import { addSectionToContainer, removeSectionFromContainer } from '$lib/actions/collection/section-container.svelte';
+	import { getContext } from 'svelte';
+	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
 
 	let {
-		node = $bindable<SectionContainer>(),
+		path,
 		refs,
-		onUnmount
+		onUnmount,
 	}: {
-		node: SectionContainer;
+		path: (string | number)[];
 		refs: Refs;
 		onUnmount: () => void;
 	} = $props();
 
-	$inspect(`section container children length: ${node.children.length}`);
+	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
+	const node = documentManipulator.getByPath(path) as SectionContainer;
+	let { children } = $derived(node);
 
 	let ChildrenRenderers = $derived(
-		node?.children.map((child) => ({
+		children.map((child) => ({
 			Renderer: registry[child.activeView as keyof typeof registry] as Component<{
-				node: Section;
+				path: (string | number)[];
 				refs: Refs;
 				onUnmount: () => void;
 				addSection: (section: Section) => void;
 				findParentSection: (level: number) => Section | null;
-				onSectionMoved: (sectionId: string) => void;
+				onSectionMoved: () => void;
 			}>
 		}))
 	);
-	$inspect(`section container children renderers length: ${ChildrenRenderers.length}`);
-
-	onMount(() => {
-		console.log('mounted');
-	});
 </script>
 
-{#if node}
-	<div class="flex flex-col gap-12">
-		{console.log('children renderers length: ', ChildrenRenderers.length)}
-		{#each ChildrenRenderers as { Renderer }, index (node.children[index].id)}
-			{#key node}
-				<Renderer
-					bind:node={
-						() => {
-							console.log('supplying the node of section: ', node.children[index]?.id);
-							console.log('index: ', index);
-
-							return node.children[index];
-						},
-						(v) => (node.children[index] = v)
+<div class="flex flex-col gap-12">
+	{console.log('children renderers length in section container: ', ChildrenRenderers.length)}
+	{#each ChildrenRenderers as { Renderer }, index}
+		<Renderer
+			path={[...path, 'children', index]}
+			{refs}
+			{onUnmount}
+			addSection={(section) => {
+				onUnmount();
+				addSectionToContainer(node, section, index + 1);
+			}}
+			findParentSection={(level) => {
+				// Look for a section before the current one with the specified level
+				for (let i = index - 1; i >= 0; i--) {
+					if (node.children[i].heading.level === level) {
+						return node.children[i];
 					}
-					{refs}
-					{onUnmount}
-					addSection={(section) => {
-						onUnmount();
-						addSectionToContainer(node, section, index + 1);
-					}}
-					findParentSection={(level) => {
-						// Look for a section before the current one with the specified level
-						for (let i = index - 1; i >= 0; i--) {
-							if (node.children[i].heading.level === level) {
-								return node.children[i];
-							}
-						}
+				}
 
-						console.log('no parent section found for level: ', level);
-						return null;
-					}}
-					onSectionMoved={() => {
-						removeSectionFromContainer(node, index);
-					}}
-				/>
-			{/key}
-		{/each}
-	</div>
-{/if}
+				console.log('no parent section found for level: ', level);
+				return null;
+			}}
+			onSectionMoved={() => {
+				removeSectionFromContainer(node, index);
+			}}
+		/>
+	{/each}
+</div>

--- a/src/lib/view/collection/section-container/Sidebar.svelte
+++ b/src/lib/view/collection/section-container/Sidebar.svelte
@@ -5,18 +5,23 @@
 	import type { Component } from 'svelte';
 	import type { z } from 'zod';
 	import type { Refs } from '$lib/components/Document.svelte';
+	import { getContext } from 'svelte';
+	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
 
 	type SectionContainer = z.infer<typeof sectionContainer>;
 
 	let {
-		node,
+		path,
 		refs,
 		onUnmount
 	}: {
-		node: SectionContainer;
+		path: (string | number)[];
 		refs: Refs;
 		onUnmount: () => void;
 	} = $props();
+	
+	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
+	const node = documentManipulator.getByPath(path) as SectionContainer;
 	let { children, view, activeView } = $derived(node);
 
 	let sidebarState = $derived(
@@ -34,15 +39,16 @@
 			HeadingRenderer: registry[
 				child.heading.activeView as keyof typeof registry
 			] as unknown as Component<{
-				node: ContentHeading;
+				path: (string | number)[];
 				refs: Refs;
 				additionalFlipId?: string;
 				onUnmount: () => void;
 			}>,
-			SummaryRenderers: child.summary.map((summaryChild) => ({
+			SummaryRenderers: child.summary.map((summaryChild, summaryIndex) => ({
 				summaryChild,
+				summaryIndex,
 				Renderer: registry[summaryChild.activeView as keyof typeof registry] as Component<{
-					node: typeof summaryChild;
+					path: (string | number)[];
 					refs: Refs;
 					additionalFlipId?: string;
 					onUnmount: () => void;
@@ -54,7 +60,7 @@
 	// Prepare renderer for the active section
 	let ActiveSectionRenderer = $derived(
 		registry[children[sidebarState.activeIndex].activeView as keyof typeof registry] as Component<{
-			node: Section;
+			path: (string | number)[];
 			refs: Refs;
 			onUnmount: () => void;
 		}>
@@ -76,7 +82,7 @@
 				<div class="sidebar-item first:pt-0 p-5" on:click={() => setActiveSection(index)}>
 					<div class="heading">
 						<HeadingRenderer
-							node={child.heading}
+							path={[...path, 'children', index, 'heading']}
 							additionalFlipId={'sidebar-item-' + index}
 							{refs}
 							{onUnmount}
@@ -85,9 +91,9 @@
 
 					{#if SummaryRenderers.length > 0}
 						<div class="summary">
-							{#each SummaryRenderers as { summaryChild, Renderer }}
+							{#each SummaryRenderers as { summaryChild, summaryIndex, Renderer }}
 								<Renderer
-									node={summaryChild}
+									path={[...path, 'children', index, 'summary', summaryIndex]}
 									additionalFlipId={'sidebar-item-' + index}
 									{refs}
 									{onUnmount}
@@ -101,7 +107,7 @@
 
 		<!-- Content -->
 		<div class="content grow basis-0 pt-0 p-2" style:width="{100 -sidebarState.percentageWidth}%">
-			<ActiveSectionRenderer node={children[sidebarState.activeIndex]} {refs} {onUnmount} />
+			<ActiveSectionRenderer path={[...path, 'children', sidebarState.activeIndex]} {refs} {onUnmount} />
 		</div>
 	</div>
 {/key}

--- a/src/lib/view/collection/section-container/TableOfContent/Controls.svelte
+++ b/src/lib/view/collection/section-container/TableOfContent/Controls.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, getContext } from 'svelte';
 	import type { z } from 'zod';
 	import type { sectionContainer } from '$lib/model/collection';
 	import { float } from '$lib/view/utils/float.svelte';
+	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
 
 	let {
-		node,
+		path,
 		onUnmount,
 		directions,
 		isTableHovered
 	}: {
-		node: z.infer<typeof sectionContainer>;
+		path: (string | number)[];
 		onUnmount: () => void;
 		directions: {
 			type: string;
@@ -22,6 +23,9 @@
 		}[];
 		isTableHovered: boolean;
 	} = $props();
+	
+	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
+	const node = documentManipulator.getByPath(path) as z.infer<typeof sectionContainer>;
 
 	let isHovered = $state(false);
 

--- a/src/lib/view/collection/section-container/Tabs/Controls.svelte
+++ b/src/lib/view/collection/section-container/Tabs/Controls.svelte
@@ -1,16 +1,21 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, getContext } from 'svelte';
 	import { float } from '$lib/view/utils/float.svelte';
+	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
+	import type { SectionContainer } from '$lib/model/collection';
 
 	let {
-		node,
+		path,
 		onUnmount,
 		isTabsHovered
 	}: {
-		node: any;
+		path: (string | number)[];
 		onUnmount: () => void;
 		isTabsHovered: boolean;
 	} = $props();
+	
+	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
+	const node = documentManipulator.getByPath(path) as SectionContainer;
 
 	let isHovered = $state(false);
 

--- a/src/lib/view/content/heading/Heading.svelte
+++ b/src/lib/view/content/heading/Heading.svelte
@@ -11,10 +11,8 @@
 	import type { NavigationHandler } from '$lib/services/navigation/types';
 	import { createNavigationPlugin } from './navigationPlugin';
 	import { createLevelPlugin } from './levelPlugin';
-
-	let documentNode: Document = getContext('document');
-
-	const getHeadingSize = (level: number) => {
+	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
+    	const getHeadingSize = (level: number) => {
 		switch (level) {
 			case 1:
 				return 'prose-h1:text-6xl';
@@ -28,7 +26,7 @@
 	};
 
 	type Props = {
-		node: ContentHeading;
+		path: (string | number)[];
 		refs: Record<
 			string,
 			{ element: HTMLElement; animateAbsolute: boolean; animateNested: boolean }
@@ -42,7 +40,7 @@
 	};
 
 	let {
-		node = $bindable<ContentHeading>(),
+		path,
 		refs,
 		onUnmount,
 		updateParent,
@@ -51,7 +49,12 @@
 		getPrevEditable,
 		onLevelIncrease
 	}: Props = $props();
+
+	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
+	const node = documentManipulator.getByPath(path) as ContentHeading;
 	let { content, level } = $derived(node);
+
+	let documentNode = getContext('document') as Document;
 
 	let headingContent = $derived(`# ${content}`);
 	let headingSize = $derived(getHeadingSize(level));

--- a/src/lib/view/content/heading/levelPlugin.ts
+++ b/src/lib/view/content/heading/levelPlugin.ts
@@ -21,6 +21,7 @@ export function createLevelPlugin(
 ): Plugin {
   return keymap({
     Tab: (state) => {
+        console.log("Tab key pressed");
       // Check if cursor is at the beginning
       const { selection } = state;
       const atStart = selection.$head.pos === 1;

--- a/src/lib/view/content/paragraph/Paragraph.svelte
+++ b/src/lib/view/content/paragraph/Paragraph.svelte
@@ -13,9 +13,10 @@
 	import type { NavigationHandler } from '$lib/services/navigation/types';
 	import { createNavigationPlugin } from '../heading/navigationPlugin';
 	import ParagraphControls from './ParagraphControls.svelte';
+	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
 
 	type Props = {
-		node: ContentParagraph;
+		path: (string | number)[];
 		refs: Record<
 			string,
 			{ element: HTMLElement; animateAbsolute: boolean; animateNested: boolean }
@@ -29,7 +30,7 @@
 		getPrevEditable?: NavigationHandler;
 	};
 	let {
-		node = $bindable<ContentParagraph>(),
+		path,
 		refs,
 		additionalFlipId,
 		updateParent,
@@ -39,9 +40,11 @@
 		getNextEditable,
 		getPrevEditable
 	}: Props = $props();
-	// let enterPressed = $state<boolean>(false);
-	let { content } = $derived(node);
+	
 	let documentNode: Document = getContext('document');
+	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
+	const node = $derived(documentManipulator.getByPath(path) as ContentParagraph);
+	let { content } = $derived(node);
 	let isParagraphHovered = $state(false);
 
 	// Create the plugins array
@@ -186,7 +189,7 @@
 			e.stopPropagation();
 		}
 	}}
-	class="leading-7 relative"
+	class="mt-6 leading-7 first:mt-0 relative"
 	bind:this={ref}
 	onmouseenter={() => isParagraphHovered = true}
 	onmouseleave={() => isParagraphHovered = false}


### PR DESCRIPTION
the previous way we updated things as changes happen was through two way bindings between adjacent parent and child components. However this introduced problems especially at deeper nodes in the hierarchy.

I changed it to instead of using this stupid ahh binding hahah, I have a single global state for the document, and this state is shared across all, where each component get a particular sub view of this global document.

The result? When you update a node, you just update directly to the document object, and Svelte' reactivity system handles making sure that changes that need to happen, happen. You don't have to go through all these crazy binding systems.