### PR TITLE
overidden summary, heading, and changed style to be more subtle

### DIFF
--- a/src/lib/view/collection/section-container/Card/Card.svelte
+++ b/src/lib/view/collection/section-container/Card/Card.svelte
@@ -32,6 +32,9 @@
 		updateParent?: () => void;
 		getNextEditable?: NavigationHandler;
 		getPrevEditable?: NavigationHandler;
+        overrides?: {
+            class?: string;
+        };
 		documentNode?: Document;
 	};
 
@@ -39,6 +42,9 @@
 		path: (string | number)[];
 		refs: Refs;
 		onUnmount: () => void;
+        overrides?: {
+            class?: string;
+        };
 		updateParent?: () => void;
 		onSplit?: (blocks: [string, string]) => void;
 		getNextEditable?: NavigationHandler;
@@ -101,18 +107,25 @@
 
 	<div class="container flex flex-wrap" style:--perRow={perRow} style:--gap={`${gap}px`}>
 		{#each SectionRenderers as { child, sectionIndex, HeadingRenderer, SummaryRenderers }}
-			<div class="card border-1 border-black p-5">
+			<div class="card border-1 border-gray-400 p-5">
 				<HeadingRenderer
 					path={[...path, 'children', sectionIndex, 'heading']}
 					{refs}
 					{onUnmount}
 					{...createHeadingNavProps(child, node, sectionIndex, document)}
+                    overrides={{
+                        class: 'prose-h1:text-xl',
+                    }}
+
 				/>
 				{#each SummaryRenderers as { summaryChild, summaryIndex, Renderer }}
 					<Renderer
 						path={[...path, 'children', sectionIndex, 'summary', summaryIndex]}
 						{refs}
 						{onUnmount}
+                        overrides={{
+                            class: 'prose-p:text-xs prose-p:text-gray-500',
+                        }}
 						{...createSummaryNavProps(child, node, summaryChild.id, sectionIndex, document)}
 					/>
 				{/each}

--- a/src/lib/view/collection/section-container/Sidebar.svelte
+++ b/src/lib/view/collection/section-container/Sidebar.svelte
@@ -19,8 +19,8 @@
 		refs: Refs;
 		onUnmount: () => void;
 	} = $props();
-	
-    const document = getContext('document') as Document;
+
+	const document = getContext('document') as Document;
 	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
 	const node = documentManipulator.getByPath(path) as SectionContainer;
 	let { children, view, activeView } = $derived(node);
@@ -44,6 +44,7 @@
 				refs: Refs;
 				additionalFlipId?: string;
 				onUnmount: () => void;
+				overrides?: { class?: string };
 			}>,
 			SummaryRenderers: child.summary.map((summaryChild, summaryIndex) => ({
 				summaryChild,
@@ -53,6 +54,7 @@
 					refs: Refs;
 					additionalFlipId?: string;
 					onUnmount: () => void;
+					overrides?: { class?: string };
 				}>
 			}))
 		}))
@@ -64,7 +66,7 @@
 			path: (string | number)[];
 			refs: Refs;
 			onUnmount: () => void;
-			overRides?: { heading?: boolean, accommodateControls?: boolean };
+			overrides?: { heading?: boolean; accommodateControls?: boolean };
 		}>
 	);
 
@@ -80,7 +82,7 @@
 {#key children[sidebarState.activeIndex].id}
 	<div class="flex">
 		<!-- Sidebar -->
-		<div class="sidebar shrink-0" style:width="{sidebarState.percentageWidth}%">
+		<div class="border-r-1 border-gray-300 shrink-0" style:width="{sidebarState.percentageWidth}%">
 			{#each ChildrenRenderers as { child, index, HeadingRenderer, SummaryRenderers }}
 				<div class="sidebar-item first:pt-0 p-5" on:click={() => setActiveSection(index)}>
 					<div class="heading">
@@ -89,6 +91,7 @@
 							additionalFlipId={'sidebar-item-' + index}
 							{refs}
 							{onUnmount}
+							overrides={{ class: 'prose-h1:text-xl' }}
 						/>
 					</div>
 
@@ -100,6 +103,7 @@
 									additionalFlipId={'sidebar-item-' + index}
 									{refs}
 									{onUnmount}
+									overrides={{ class: 'prose-p:text-xs prose-p:text-gray-500' }}
 								/>
 							{/each}
 						</div>
@@ -109,16 +113,18 @@
 		</div>
 
 		<!-- Content -->
-		<div class="content grow basis-0 pt-0 p-2" style:width="{100 -sidebarState.percentageWidth}%">
-			<ActiveSectionRenderer overRides={{accommodateControls: true}} path={[...path, 'children', sidebarState.activeIndex]} {refs} {onUnmount} />
+		<div class="content grow basis-0 p-2 pt-0" style:width="{100 - sidebarState.percentageWidth}%">
+			<ActiveSectionRenderer
+				overrides={{ accommodateControls: true }}
+				path={[...path, 'children', sidebarState.activeIndex]}
+				{refs}
+				{onUnmount}
+			/>
 		</div>
 	</div>
 {/key}
 
 <style>
-	.sidebar {
-		border-right: 1px solid black;
-	}
 
 	.sidebar-item {
 		cursor: pointer;

--- a/src/lib/view/collection/section-container/Tabs/Tabs.svelte
+++ b/src/lib/view/collection/section-container/Tabs/Tabs.svelte
@@ -38,6 +38,7 @@
 				refs: Refs;
 				additionalFlipId?: string;
 				onUnmount: () => void;
+				overrides?: { class?: string };
 			}>
 		}))
 	);
@@ -51,7 +52,7 @@
 			path: (string | number)[];
 			refs: Refs;
 			onUnmount: () => void;
-			overRides?: { heading: boolean };
+			overrides?: { heading: boolean };
 		}>
 	);
 
@@ -118,20 +119,21 @@
 	onmouseleave={hideTabsControls}
 >
 	{#if document.state.mode === 'customize'}
-		<Controls path={path} {onUnmount} {isTabsHovered} />
+		<Controls {path} {onUnmount} {isTabsHovered} />
 	{/if}
 
 	<!-- Tabs navigation -->
 	<div class="tabs-container">
 		<div class="tabs-scroll flex overflow-x-scroll" style:gap="{gap}px" bind:this={tabsScroll}>
-			{#each ChildrenRenderers as {  index, HeadingRenderer }}
+			{#each ChildrenRenderers as { index, HeadingRenderer }}
 				<div
-					class="cursor-pointer p-5 whitespace-nowrap {index === activeIndex
-						? 'border-b-2 border-black'
+					class="cursor-pointer p-5 pb-2 whitespace-nowrap {index === activeIndex
+						? 'border-b-1 border-black'
 						: ''}"
 					onclick={() => setActiveSection(index)}
 				>
 					<HeadingRenderer
+						overrides={{ class: 'prose-h1:text-xl' }}
 						path={[...path, 'children', index, 'heading']}
 						additionalFlipId={'tab-item-' + index}
 						{refs}
@@ -153,7 +155,7 @@
 		<div class="pt-5">
 			<ActiveSectionRenderer
 				path={[...path, 'children', activeIndex]}
-				overRides={{ heading: false }}
+				overrides={{ heading: false }}
 				{refs}
 				{onUnmount}
 			/>

--- a/src/lib/view/collection/section/default/Default.svelte
+++ b/src/lib/view/collection/section/default/Default.svelte
@@ -19,7 +19,7 @@
 		path: (string | number)[];
 		refs: Refs;
 		onUnmount: () => void;
-		overRides?: { heading?: boolean; accommodateControls?: boolean };
+		overrides?: { heading?: boolean; accommodateControls?: boolean };
 		addSection: (newSection: Section) => void;
 		findParentSection: (level: number) => Section | null;
 		onSectionMoved: () => void;
@@ -29,14 +29,14 @@
 		path,
 		refs,
 		onUnmount,
-		overRides = {},
+		overrides = {},
 		addSection,
 		findParentSection,
 		onSectionMoved
 	}: Props = $props();
 
 	const defaultOverRides = { heading: true, accommodateControls: false };
-	overRides = { ...defaultOverRides, ...overRides };
+	overrides = { ...defaultOverRides, ...overrides };
 
 	let document = getContext('document') as Document;
 	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
@@ -68,6 +68,7 @@
 			Renderer: registry[child.activeView as keyof typeof registry] as Component<{
 				path: (string | number)[];
 				refs: Refs;
+                overrides?: { class?: string };
 				onUnmount: () => void;
 				onSplit: (newBlocks: [string, string]) => void;
 			}>
@@ -83,14 +84,14 @@
 
 	onMount(() => {
 		if (containerElement && controlElement) {
-			if (overRides?.accommodateControls) {
+			if (overrides?.accommodateControls) {
 				containerElement.style.paddingLeft = `${controlElement.clientWidth}px`;
 			}
 
 			// Determine which element to use as reference for the floating control
-			const referenceElement = overRides?.heading ? headingElement : contentElement;
+			const referenceElement = overrides?.heading ? headingElement : contentElement;
 			// Use 'left' for heading, 'left-start' for content
-			const placement = overRides?.heading ? 'left' : 'left-start';
+			const placement = overrides?.heading ? 'left' : 'left-start';
 
 			if (referenceElement) {
 				return float(
@@ -111,7 +112,7 @@
 />
 
 <div class="container flex flex-col gap-7" bind:this={containerElement}>
-	{#if overRides && overRides.heading}
+	{#if overrides && overrides.heading}
 		{#key node.heading.id}
 			<div bind:this={headingElement}>
 				<HeadingRenderer
@@ -159,6 +160,7 @@
 				<Renderer
 					path={[...path, 'summary', i]}
 					{refs}
+                    overrides={{ class: 'prose-p:text-xs prose-p:text-gray-500' }}
 					onSplit={(newBlocks) => {
 						splitParagraph(node, 'summary', newBlocks, document, i);
 					}}

--- a/src/lib/view/collection/section/write/Write.svelte
+++ b/src/lib/view/collection/section/write/Write.svelte
@@ -20,7 +20,7 @@
 		path: (string | number)[];
 		refs: Refs;
 		onUnmount: () => void;
-		overRides?: { heading?: boolean; accommodateControls?: boolean };
+		overrides?: { heading?: boolean; accommodateControls?: boolean };
 		addSection?: (newSection: Section) => void;
 		findParentSection?: (level: number) => Section | null;
 		onSectionMoved?: () => void;
@@ -30,14 +30,14 @@
 		path,
 		refs,
 		onUnmount,
-		overRides = {},
+		overrides = {},
 		addSection = () => {},
 		findParentSection = () => null,
 		onSectionMoved = () => {}
 	}: Props = $props();
 
 	const defaultOverRides = { heading: true, accommodateControls: false };
-	overRides = { ...defaultOverRides, ...overRides };
+	overrides = { ...defaultOverRides, ...overrides };
 
 	let document = getContext('document') as Document;
 	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
@@ -79,7 +79,7 @@
 </script>
 
 <div class="container flex flex-col gap-7">
-	{#if overRides && overRides.heading}
+	{#if overrides && overrides.heading}
 		{#key node.heading.id}
 			<HeadingRenderer
 				path={[...path, 'heading']}

--- a/src/lib/view/content/heading/Heading.svelte
+++ b/src/lib/view/content/heading/Heading.svelte
@@ -32,6 +32,9 @@
 			string,
 			{ element: HTMLElement; animateAbsolute: boolean; animateNested: boolean }
 		>;
+		overrides?: {
+            class?: string;
+		};
 		onUnmount: () => void;
 		updateParent: () => void;
 		additionalFlipId?: string;
@@ -45,6 +48,7 @@
 		path,
 		refs,
 		onUnmount,
+		overrides = {},
 		updateParent,
 		additionalFlipId,
 		getNextEditable,
@@ -52,6 +56,11 @@
 		onLevelIncrease,
 		onEnterAtEnd
 	}: Props = $props();
+
+    const defaultOverrides = {
+        class: ''
+    }
+    overrides = { ...defaultOverrides, ...overrides };
 
 	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
 	const node = documentManipulator.getByPath(path) as ContentHeading;
@@ -210,7 +219,7 @@
 			e.stopPropagation();
 		}
 	}}
-	class={[headingSize, 'prose-h1:inline-block', 'prose-h1:font-semibold']}
+	class={[headingSize, 'prose-h1:inline-block', 'prose-h1:font-semibold', overrides.class]}
 ></div>
 
 <svelte:document

--- a/src/lib/view/content/paragraph/Paragraph.svelte
+++ b/src/lib/view/content/paragraph/Paragraph.svelte
@@ -28,6 +28,7 @@
 		onConvertToHeading?: (paragraphId: string) => void;
 		getNextEditable?: NavigationHandler;
 		getPrevEditable?: NavigationHandler;
+        overrides?: { class?: string };
 	};
 	let {
 		path,
@@ -38,8 +39,14 @@
 		onSplit,
 		onConvertToHeading,
 		getNextEditable,
-		getPrevEditable
+		getPrevEditable,
+        overrides
 	}: Props = $props();
+
+    const defaultOverrides = {
+        class: ''
+    }
+    overrides = { ...defaultOverrides, ...overrides };
 	
 	let documentNode: Document = getContext('document');
 	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
@@ -189,7 +196,7 @@
 			e.stopPropagation();
 		}
 	}}
-	class="mt-6 leading-7 first:mt-0 relative"
+	class="mt-6 leading-7 first:mt-0 relative {overrides.class}"
 	bind:this={ref}
 	onmouseenter={() => isParagraphHovered = true}
 	onmouseleave={() => isParagraphHovered = false}


### PR DESCRIPTION
The problem is that the looks of the overall document did not feel natural. Having the big ass font size for section names don't look right. So the main purpose is to make tabs and sidebar titles to be small.

Then, some opportunities to improve came along the way. So, I tried to pursue them too.

1. enabling overrides for heading and paragraph

the purpose is to be able to control the sizes beyond the default. We are using this to control heading and summary in sidebar, tabs, card views, so that they look more natural.

- summary become `text-xs`
- headings become `text-xl`

2. styling changes to make the looks "softer" and more smooth, instead of the high contrasts

- make the color of sidebar separator lighter
- tabs to have narrower bottom padding
- color summary to be gray
- card border to be gray

3. fixing english error, overRide -> override