### PR TITLE
fix heading increment issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,5 @@ pressing tab on a heading should not work when the parent's heading is one level
 In sidebar view, if you consider the active section being rendered, there are two consecutive appearances of  a heading. However if you update one, the other does not get updated.
 
 There's a bug right now in which we wouldn't want animation when switching tabs, or switching the active item in the sidebar. Strangely enough it works during customize mode, but not when viewing a published document.
+
+there is a bug where when you have a document whise current structure is H1 (A), H1 (B), H1 (C), and then you increase the level by using tab for H1 (B), it turns to H1 (A), H2 (B), H2 (B). This wrong. However, the document state seems to be updated correctly. So my guess would be this is an issue with not trigerring svelte's reactivity, rather than purely logic issue.

--- a/src/lib/actions/collection/section-container.svelte.ts
+++ b/src/lib/actions/collection/section-container.svelte.ts
@@ -27,6 +27,8 @@ export function removeSectionFromContainer(node: SectionContainer, index: number
 	if (index >= 0 && index < node.children.length) {
 		console.log('valid and removing section');
 		node.children.splice(index, 1);
+        console.log('just removed section');
+
 		node.last_modified = new Date().toISOString();
 	}
 }

--- a/src/lib/actions/collection/section.svelte.ts
+++ b/src/lib/actions/collection/section.svelte.ts
@@ -47,77 +47,74 @@ export async function splitParagraph(
 	}
 }
 
+// there is a temporary state where the children of a section are not meant to be the children
+// so it has to be moved upward to ba direct siblings of the section
+function adjustChildren(node: Section, newContainer: SectionContainer) {
+    const index = newContainer.children.findIndex((child) => child.id === node.id);
+    const sectionContainers = node.children.filter((child) => child.type === 'section-container');
+    let sectionSeen = 0;
+    for (let i = 0; i < sectionContainers.length; i++) {
+        const child = sectionContainers[i];
+        const sectionContainer = child as SectionContainer;
+
+        for (let j = 0; j < sectionContainer.children.length; j++) {
+            newContainer.children.splice(index + sectionSeen + j + 1, 0, sectionContainer.children[j]);
+        }
+        sectionSeen += sectionContainer.children.length;
+    }
+
+    const sectionContainerIds = sectionContainers.map((child) => child.id);
+    node.children = node.children.filter((child) => !sectionContainerIds.includes(child.id));
+}
+
 /**
  * Handles the restructuring when a heading level increases by 1
  *
  * @param node The section whose heading level would increase
- * @param findParentSection A callback to find a parent section with the appropriate level
- * @param onSectionMoved A callback to notify when the section has been moved
+ * @param findParentSection A callback to find a parent section with the appropriate level in the section container of the node
+ * @param removeSectionFromContainer A callback to notify when the section has been moved
  * @returns True if the level change should be allowed, false otherwise
  */
 export function handleHeadingLevelIncrease(
 	node: Section,
 	findParentSection: (level: number) => Section | null,
-	onSectionMoved: (sectionId: string) => void
+	removeSectionFromContainer: (sectionId: string) => void
 ): boolean {
 	const currentLevel = node.heading.level;
 	const newLevel = currentLevel + 1;
 
-	// Find a section with level one less than the new level
 	const parentSection = findParentSection(currentLevel);
-
-	// If no parent found, prevent the change
 	if (!parentSection) return false;
 
-	// Increase the heading level
 	console.log('increasing level of section');
 	node.heading.level = newLevel;
 
-	// Check if the last child of the parent section is a section container
 	const lastChild =
 		parentSection.children.length > 0
 			? parentSection.children[parentSection.children.length - 1]
 			: null;
 
-	try {
-		// Use the Zod schema to validate if the last child is a section container
-		if (lastChild && sectionContainer.safeParse(lastChild).success) {
-			// If the last child is a section container, add the section to it
-			console.log('adding section to existing section container');
-			(lastChild as SectionContainer).children.push(node);
-			lastChild.last_modified = new Date().toISOString();
-		} else {
-			// If the last child is not a section container, create a new one
-			console.log('creating new section container');
-			const newContainer = createSectionContainer();
-			newContainer.children.push(node);
+	let newContainer: SectionContainer = createSectionContainer();
 
-			// Add the new container to the parent section
-			console.log('adding new section container to parent section');
-			parentSection.children.push(newContainer);
-		}
-	} catch {
-		// If there's an error with the validation, create a new container
-		console.log('error validating section container, creating new one');
-		const newContainer = createSectionContainer();
-		newContainer.children.push(node);
-
-		// Add the new container to the parent section
-		console.log('adding new section container to parent section');
+	if (lastChild && sectionContainer.safeParse(lastChild).success) {
+		newContainer = lastChild as SectionContainer;
+		(lastChild as SectionContainer).children.push(node);
+		lastChild.last_modified = new Date().toISOString();
+	} else {
 		parentSection.children.push(newContainer);
+        newContainer = parentSection.children[parentSection.children.length - 1] as SectionContainer;
+		newContainer.children.push(node);
 	}
 
-	// Update timestamps
 	node.heading.last_modified = new Date().toISOString();
 	parentSection.last_modified = new Date().toISOString();
 
-	// Notify the container that this section has been moved
-	console.log('notifying container that section has been moved');
-	onSectionMoved(node.id);
+	removeSectionFromContainer(node.id);
+    adjustChildren(node, newContainer);
 
 	return true;
 }
-
+  
 /**
  * Handles Enter key press at the end of a heading
  *

--- a/src/lib/components/Document.svelte
+++ b/src/lib/components/Document.svelte
@@ -100,6 +100,8 @@
             flipState = null;
         }
 	});
+
+    $inspect(node)
 </script>
 
 {#if !isDocumentViewPage}

--- a/src/lib/view/collection/section-container/Default/Default.svelte
+++ b/src/lib/view/collection/section-container/Default/Default.svelte
@@ -38,7 +38,7 @@
 				onUnmount: () => void;
 				addSection: (section: Section) => void;
 				findParentSection: (level: number) => Section | null;
-				onSectionMoved: () => void;
+				removeSectionFromContainer: () => void;
 			}>
 		}))
 	);
@@ -70,7 +70,7 @@
 				console.log('no parent section found for level: ', level);
 				return null;
 			}}
-			onSectionMoved={() => {
+			removeSectionFromContainer={() => {
 				removeSectionFromContainer(node, index);
 			}}
 		/>

--- a/src/lib/view/collection/section-container/Write.svelte
+++ b/src/lib/view/collection/section-container/Write.svelte
@@ -29,7 +29,7 @@
 			onUnmount: () => void;
 			addSection: (section: Section) => void;
 			findParentSection: (level: number) => Section | null;
-			onSectionMoved: () => void;
+			removeSectionFromContainer: () => void;
 		}>;
 	};
 
@@ -52,7 +52,9 @@
 			}
 
 			return {
-				Renderer: registry[child.activeView as keyof typeof registry] as ChildrenRenderersType['Renderer']
+				Renderer: registry[
+					child.activeView as keyof typeof registry
+				] as ChildrenRenderersType['Renderer']
 			};
 		})
 	);
@@ -80,7 +82,7 @@
 				console.log('no parent section found for level: ', level);
 				return null;
 			}}
-			onSectionMoved={() => {
+			removeSectionFromContainer={() => {
 				removeSectionFromContainer(node, index);
 			}}
 		/>

--- a/src/lib/view/collection/section/default/Default.svelte
+++ b/src/lib/view/collection/section/default/Default.svelte
@@ -22,7 +22,7 @@
 		overrides?: { heading?: boolean; accommodateControls?: boolean };
 		addSection: (newSection: Section) => void;
 		findParentSection: (level: number) => Section | null;
-		onSectionMoved: () => void;
+		removeSectionFromContainer: () => void;
 	};
 	type ViewState = { state: 'expanded' | 'summary' | 'collapsed' };
 	let {
@@ -32,7 +32,7 @@
 		overrides = {},
 		addSection,
 		findParentSection,
-		onSectionMoved
+		removeSectionFromContainer
 	}: Props = $props();
 
 	const defaultOverRides = { heading: true, accommodateControls: false };
@@ -68,7 +68,7 @@
 			Renderer: registry[child.activeView as keyof typeof registry] as Component<{
 				path: (string | number)[];
 				refs: Refs;
-                overrides?: { class?: string };
+				overrides?: { class?: string };
 				onUnmount: () => void;
 				onSplit: (newBlocks: [string, string]) => void;
 			}>
@@ -121,7 +121,7 @@
 					{onUnmount}
 					onLevelIncrease={() => {
 						console.log('onLevelIncrease in section');
-						return handleHeadingLevelIncrease(node, findParentSection, onSectionMoved);
+						return handleHeadingLevelIncrease(node, findParentSection, removeSectionFromContainer);
 					}}
 					onEnterAtEnd={() => {
 						console.log('onEnterAtEnd in section');
@@ -160,7 +160,7 @@
 				<Renderer
 					path={[...path, 'summary', i]}
 					{refs}
-                    overrides={{ class: 'prose-p:text-xs prose-p:text-gray-500' }}
+					overrides={{ class: 'prose-p:text-xs prose-p:text-gray-500' }}
 					onSplit={(newBlocks) => {
 						splitParagraph(node, 'summary', newBlocks, document, i);
 					}}

--- a/src/lib/view/collection/section/write/Write.svelte
+++ b/src/lib/view/collection/section/write/Write.svelte
@@ -23,7 +23,7 @@
 		overrides?: { heading?: boolean; accommodateControls?: boolean };
 		addSection?: (newSection: Section) => void;
 		findParentSection?: (level: number) => Section | null;
-		onSectionMoved?: () => void;
+		removeSectionFromContainer?: () => void;
 	};
 	type ViewState = { state: 'expanded' | 'summary' | 'collapsed' };
 	let {
@@ -33,7 +33,7 @@
 		overrides = {},
 		addSection = () => {},
 		findParentSection = () => null,
-		onSectionMoved = () => {}
+		removeSectionFromContainer = () => {}
 	}: Props = $props();
 
 	const defaultOverRides = { heading: true, accommodateControls: false };
@@ -87,7 +87,7 @@
 				{onUnmount}
 				onLevelIncrease={() => {
 					console.log('onLevelIncrease in section');
-					return handleHeadingLevelIncrease(node, findParentSection, onSectionMoved);
+					return handleHeadingLevelIncrease(node, findParentSection, removeSectionFromContainer);
 				}}
 				onEnterAtEnd={() => {
 					console.log('onEnterAtEnd in section');


### PR DESCRIPTION
there was an issue where if we have a document of the following structure:

```
H1

H1  <-
|
| H2
|
| H2

```

If we increase the level of the pointed heading, we want to get this

```
H1
|
| H2 
|
| H2
|
| H2

```

But instead, we got this

```
H1
|
| H2 
| |
| | H2
| |
| | H2

```
And this PR fixes that issue.