### PR TITLE
switch seamlessly between one view to the default view

### DIFF
--- a/src/lib/view/collection/section-container/Card/Card.svelte
+++ b/src/lib/view/collection/section-container/Card/Card.svelte
@@ -17,6 +17,7 @@
 	import type { NavigationHandler } from '$lib/services/navigation/types';
 	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
 	import Chip from '$lib/components/Chip.svelte';
+	import Default from '../Default/Default.svelte';
 
 	const document = getContext('document') as Document;
 	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
@@ -35,6 +36,7 @@
 		overrides?: {
 			class?: string;
 		};
+		onClickReadMode?: () => void;
 		documentNode?: Document;
 	};
 
@@ -100,49 +102,66 @@
 	}
 </script>
 
-<div class="card-container" onmouseenter={showCardControls} onmouseleave={hideCardControls}>
-	{#if document.state.mode === 'customize'}
-		<Controls {path} {onUnmount} {isCardHovered} />
-	{/if}
+{#if !node.children.every((child) => {
+	const defaultView = child.view.find((v) => v.type === 'collection/section/default');
+	return defaultView?.state === 'summary';
+})}
+	<div class="card-container" onmouseenter={showCardControls} onmouseleave={hideCardControls}>
+		<Default {path} {refs} {onUnmount} />
+	</div>
+{:else}
+	<div class="card-container" onmouseenter={showCardControls} onmouseleave={hideCardControls}>
+		{#if document.state.mode === 'customize'}
+			<Controls {path} {onUnmount} {isCardHovered} />
+		{/if}
 
-	<div class="card-grid" style:--gap={`${gap}px`} style:--min-card-width={`${minCardWidth}px`}>
-		{#each SectionRenderers as { child, sectionIndex, HeadingRenderer, SummaryRenderers }}
-			<div class="card border-1 border-gray-400 p-5">
-				<HeadingRenderer
-					path={[...path, 'children', sectionIndex, 'heading']}
-					{refs}
-					{onUnmount}
-					{...createHeadingNavProps(child, node, sectionIndex, document)}
-                    overrides={{
-                        class: 'prose-h1:text-xl',
-                    }}
-
-				/>
-				{#each SummaryRenderers as { summaryChild, summaryIndex, Renderer }}
-					<Renderer
-						path={[...path, 'children', sectionIndex, 'summary', summaryIndex]}
+		<div class="card-grid" style:--gap={`${gap}px`} style:--min-card-width={`${minCardWidth}px`}>
+			{#each SectionRenderers as { child, sectionIndex, HeadingRenderer, SummaryRenderers }}
+				<div class="card border-1 border-gray-400 p-5">
+					<HeadingRenderer
+						path={[...path, 'children', sectionIndex, 'heading']}
 						{refs}
 						{onUnmount}
-                        overrides={{
-                            class: 'prose-p:text-xs prose-p:text-gray-500',
-                        }}
-						{...createSummaryNavProps(child, node, summaryChild.id, sectionIndex, document)}
+						{...createHeadingNavProps(child, node, sectionIndex, document)}
+						overrides={{
+							class: 'prose-h1:text-xl'
+						}}
+						onClickReadMode={() => {
+							// toggle the state in the default view, not change it to the default view. Change the state in the default view.
+							const defaultView = node.children[sectionIndex].view.find(
+								(v) => v.type === 'collection/section/default'
+							);
+							if (defaultView) {
+								defaultView.state = defaultView.state === 'expanded' ? 'summary' : 'expanded';
+							}
+						}}
 					/>
-				{/each}
-			</div>
-		{/each}
+					{#each SummaryRenderers as { summaryChild, summaryIndex, Renderer }}
+						<Renderer
+							path={[...path, 'children', sectionIndex, 'summary', summaryIndex]}
+							{refs}
+							{onUnmount}
+							overrides={{
+								class: 'prose-p:text-xs prose-p:text-gray-500'
+							}}
+							{...createSummaryNavProps(child, node, summaryChild.id, sectionIndex, document)}
+						/>
+					{/each}
+				</div>
+			{/each}
 
-		{#if document.state.mode !== 'read'}
-			<Chip
-				onclick={() => {
-					onUnmount();
-					addSection(node, node.children[0].heading.level);
-				}}
-				label="Add Section"
-			/>
-		{/if}
+			{#if document.state.mode !== 'read'}
+				<Chip
+					onclick={() => {
+						onUnmount();
+						addSection(node, node.children[0].heading.level);
+					}}
+					label="Add Section"
+				/>
+			{/if}
+		</div>
 	</div>
-</div>
+{/if}
 
 <style lang="postcss">
 	.card-container {

--- a/src/lib/view/collection/section-container/Default/Controls.svelte
+++ b/src/lib/view/collection/section-container/Default/Controls.svelte
@@ -37,6 +37,10 @@
 
 	function switchToCard() {
 		onUnmount();
+		node.children.forEach((child) => {
+			const defaultView = child.view.find((view) => view.type === 'collection/section/default');
+			defaultView && (defaultView.state = 'summary');
+		});
 		node.activeView = 'collection/section-container/card';
 	}
 

--- a/src/lib/view/collection/section-container/TableOfContent/Controls.svelte
+++ b/src/lib/view/collection/section-container/TableOfContent/Controls.svelte
@@ -62,6 +62,10 @@
 		onclick={() => {
 			console.log('clicked');
 			onUnmount();
+			node.children.forEach((child) => {
+				const defaultView = child.view.find((view) => view.type === 'collection/section/default');
+				defaultView && (defaultView.state = 'summary');
+			});
 			node.activeView = 'collection/section-container/card';
 		}}
 	>

--- a/src/lib/view/collection/section-container/Tabs/Controls.svelte
+++ b/src/lib/view/collection/section-container/Tabs/Controls.svelte
@@ -13,7 +13,7 @@
 		onUnmount: () => void;
 		isTabsHovered: boolean;
 	} = $props();
-	
+
 	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
 	const node = documentManipulator.getByPath(path) as SectionContainer;
 
@@ -37,6 +37,10 @@
 
 	function switchToCard() {
 		onUnmount();
+		node.children.forEach((child) => {
+			const defaultView = child.view.find((view) => view.type === 'collection/section/default');
+			defaultView && (defaultView.state = 'summary');
+		});
 		node.activeView = 'collection/section-container/card';
 	}
 
@@ -60,9 +64,7 @@
 	<button class="rounded-md bg-blue-500 p-2 text-white" onclick={switchToTableOfContents}>
 		toc
 	</button>
-	<button class="rounded-md bg-blue-500 p-2 text-white" onclick={switchToCard}>
-		card
-	</button>
+	<button class="rounded-md bg-blue-500 p-2 text-white" onclick={switchToCard}> card </button>
 </div>
 
 <div bind:this={referenceElement} class="reference-element w-full"></div>


### PR DESCRIPTION
We should be able to expand and contract. 

previously, card view was as is, and you cannot expand it. It is just a collection of static sections.

<img width="1114" alt="Screenshot 2025-04-08 at 21 46 10" src="https://github.com/user-attachments/assets/2893eaa3-27e7-4821-8c72-753cf1959728" />

But now, when you click on one's heading, it expands. And then when every section is collapsed, it turns automatically to card back.

<img width="1435" alt="Screenshot 2025-04-08 at 21 51 51" src="https://github.com/user-attachments/assets/42902d56-c99e-48c7-896c-e16cd56debc2" />

