### PR TITLE
delete on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,5 @@ there is a bug where when you have a document whise current structure is H1 (A),
 There is an issue where if you are in the editor mode, and you go from read to customize view, the summary/expand toggles that show up are not at the right place. It seems like only one is showing at the top left.
 
 Animation is displaying in the published view for switching tabs, etc. We don't want it to work for those kind of things. But it is proper in the editor's read view.
+
+When you press backspace at the start of a paragraph, cursor is just gone, not transfered. Should be transferred to previous paragraph, and the point where the two paragraphs are joined.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -39,16 +39,44 @@ We're implementing a path-based component access pattern to replace the two-way 
   - Updated Paragraph component to use the backspace plugin
   - Implemented onJoinWithPrevious callbacks in Write component for both children and summary paragraphs
 
+## Backspace Functionality Issue and Solution
+We've identified a race condition in the paragraph joining functionality:
+
+1. **Issue Diagnosis**:
+   - When backspace is pressed at the start of a paragraph, the backspace plugin correctly calls `onJoinWithPrevious`
+   - `joinWithPreviousParagraph` joins the content and removes the current paragraph
+   - The content is joined correctly in the document model
+   - However, the paragraph is deleted instead of joined in the final UI state
+
+2. **Root Cause**:
+   - The race condition occurs between two separate processes:
+     - Direct document model updates in `joinWithPreviousParagraph`
+     - ProseMirror's transaction processing in `dispatchTransaction`
+   - The key issue is that `prevBlock.content` and `prevBlock.last_modified` are updated in separate steps
+   - This creates a timing window where the component re-renders due to the key change (`node.children[i].last_modified + node.children[i].id`)
+   - The old ProseMirror instance's transaction processing overwrites the correctly joined content with stale data
+
+3. **Solution Plan**:
+   - Implement atomic updates for content and last_modified in `joinWithPreviousParagraph`
+   - Create a helper function in DocumentManipulator to update multiple properties in a single operation
+   - This ensures that both properties are updated together, preventing the race condition
+   - Example implementation:
+     ```typescript
+     // Update previous block atomically
+     const updates = {
+       content: prevBlock.content + currentBlock.content,
+       last_modified: new Date().toISOString()
+     };
+     Object.assign(prevBlock, updates);
+     ```
+
 ## Next Steps
+- Implement the atomic update solution for the backspace functionality
 - Test the heading level decrease functionality with complex nested structures
 - Address UI update issues (currently requires mode switching to see changes)
 - Optimize performance for large documents
 - Update documentation with the new access pattern
 - Consider adding debugging tools for path-based access
-- Fix backspace functionality issues:
-  - Empty transaction steps being logged (transaction steps: [])
-  - Document being set to wrong version where content is deleted instead of joined
-  - Cursor disappearing after backspace operation
 
 ## Active Decisions
 - Using path-based access instead of two-way binding for nested objects
@@ -56,3 +84,4 @@ We're implementing a path-based component access pattern to replace the two-way 
 - Leveraging Svelte 5's reactivity system for direct mutations
 - Maintaining existing callback patterns for actions
 - Following a consistent pattern for component props (paths instead of nodes)
+- Implementing atomic updates for properties that affect component keying

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -33,6 +33,11 @@ We're implementing a path-based component access pattern to replace the two-way 
   - Control components (for Card, TableOfContents, Tabs)
 - Maintained existing callback patterns for actions
 - Ensured reactivity through direct mutations
+- Implemented backspace functionality to join blocks when pressing backspace at the start of a block:
+  - Created backspacePlugin.ts to detect backspace at the start of content
+  - Added joinWithPreviousParagraph function to handle joining paragraphs
+  - Updated Paragraph component to use the backspace plugin
+  - Implemented onJoinWithPrevious callbacks in Write component for both children and summary paragraphs
 
 ## Next Steps
 - Test the heading level decrease functionality with complex nested structures
@@ -40,6 +45,10 @@ We're implementing a path-based component access pattern to replace the two-way 
 - Optimize performance for large documents
 - Update documentation with the new access pattern
 - Consider adding debugging tools for path-based access
+- Fix backspace functionality issues:
+  - Empty transaction steps being logged (transaction steps: [])
+  - Document being set to wrong version where content is deleted instead of joined
+  - Cursor disappearing after backspace operation
 
 ## Active Decisions
 - Using path-based access instead of two-way binding for nested objects

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,6 +1,7 @@
 # Progress
 
 ## What Works
+
 - Document model and structure
 - Basic editing functionality
 - View registry for component mapping
@@ -17,8 +18,10 @@
 - Heading level increase with document restructuring
 - Heading level decrease with document restructuring
 - Path-based component access pattern
+- Backspace functionality for joining blocks (with known issues)
 
 ## What's Left to Build
+
 - Fix UI update issues with heading level changes (currently requires mode switching)
 - Complete navigation system for all view types
 - Keyboard shortcuts for common operations
@@ -33,6 +36,7 @@
 - Debugging tools for path-based access
 
 ## Current Status
+
 We've implemented a path-based component access pattern to replace the two-way binding approach. This change addresses issues with deeply nested objects, where two-way binding creates friction when accessing state from adjacent components.
 
 The new approach uses a centralized global reactive state accessed through paths:
@@ -43,6 +47,7 @@ The new approach uses a centralized global reactive state accessed through paths
 4. Child components receive extended paths (e.g., `[...path, 'children', index]`)
 
 This pattern provides several benefits:
+
 - Reduced coupling between components
 - Simplified state management with a single source of truth
 - Better performance with deeply nested structures
@@ -52,11 +57,13 @@ This pattern provides several benefits:
 We've implemented document structure updates for both heading level increases and decreases:
 
 **Heading Level Increase (Tab/Space at start of heading):**
+
 1. Check if there's a preceding section with the appropriate level (one level lower than the new heading level)
 2. If found, increase the heading level and move the section to become a child of that preceding section
 3. Update the document structure accordingly
 
 **Heading Level Decrease (Backspace at start of heading):**
+
 1. Check if decreasing the level would violate the constraint (section cannot have direct section children whose level is more than 1 above its level)
 2. If safe, perform a three-step restructuring process:
    - Step 1: Move siblings after the section to be children of that section
@@ -64,7 +71,16 @@ We've implemented document structure updates for both heading level increases an
    - Step 3: Add the section to the grandparent section container after the parent section
 3. Update the heading level and document structure
 
+**Backspace at Start of Paragraph (Join with Previous):**
+
+1. Detect when backspace is pressed at the start of a paragraph
+2. Find the previous paragraph in the same section
+3. Join the content of the current paragraph with the previous paragraph
+4. Remove the current paragraph from the document
+5. Set focus to the previous paragraph with cursor at the join point
+
 This implementation required clarifying the distinction between:
+
 - findPrecedingSection: Finds a preceding sibling section with the appropriate level
 - findParentSection: Finds the actual parent section in the hierarchy
 - findParentSectionContainer: Finds the container that holds the current section
@@ -73,6 +89,7 @@ This implementation required clarifying the distinction between:
 There is currently a UI update issue where changes don't appear immediately unless the user switches modes and goes back to write mode. This needs to be addressed in future updates.
 
 ## Known Issues
+
 - UI update issues with heading level changes (requires mode switching to see changes)
 - Edge cases in heading level increase and decrease operations
 - Navigation between different view types needs refinement
@@ -80,3 +97,8 @@ There is currently a UI update issue where changes don't appear immediately unle
 - Need to implement navigation for all container types
 - Performance optimization for large documents with many editors
 - Need to ensure all components are updated to use the path-based pattern
+- Backspace functionality issues:
+  - Empty transaction steps being logged (transaction steps: [])
+  - Document being set to wrong version where content is deleted instead of joined
+  - Cursor disappearing after backspace operation
+  - Content that should be joined is sometimes just deleted

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -64,6 +64,7 @@ flowchart TD
 - Hierarchical document model
 - Section splitting for content reorganization
 - Heading level management with document restructuring
+- Paragraph joining with backspace at start of block
 
 ```mermaid
 flowchart TD
@@ -77,6 +78,17 @@ flowchart TD
     Decrease --> Step1[Step 1: Move Siblings to Children]
     Step1 --> Step2[Step 2: Remove from Container]
     Step2 --> Step3[Step 3: Add to Grandparent Container]
+    
+    ContentOps[Content Operations] --> Split[Split Paragraph]
+    ContentOps --> Join[Join Paragraphs]
+    
+    Split --> EnterMiddle[Enter in Middle]
+    Split --> CreateTwo[Create Two Blocks]
+    
+    Join --> BackspaceStart[Backspace at Start]
+    Join --> FindPrevious[Find Previous Block]
+    FindPrevious --> MergeContent[Merge Content]
+    MergeContent --> RemoveBlock[Remove Current Block]
 ```
 
 ### UI Components

--- a/src/lib/actions/collection/section.svelte.ts
+++ b/src/lib/actions/collection/section.svelte.ts
@@ -43,6 +43,51 @@ export function moveChildrenToSection(
 	return childrenAfter;
 }
 
+/**
+ * Joins a paragraph with the previous paragraph when backspace is pressed at the start
+ * 
+ * @param node The section containing the paragraphs
+ * @param arr The array containing the paragraphs ('summary' or 'children')
+ * @param currentIndex The index of the current paragraph
+ * @param document The document node
+ * @param prevId The ID of the previous paragraph
+ * @returns True if the join was successful, false otherwise
+ */
+export function joinWithPreviousParagraph(
+	node: Section,
+	arr: 'summary' | 'children',
+	currentIndex: number,
+	document: Document,
+	prevId: string
+): boolean {
+    console.log('joining with previous paragraph');
+	if (!prevId) return false;
+	
+	// Find previous block in the array
+	const prevIndex = node[arr].findIndex(item => item.id === prevId);
+	if (prevIndex === -1 || prevIndex >= currentIndex) return false;
+	
+	// Check if both are paragraphs
+	const currentBlock = node[arr][currentIndex];
+	const prevBlock = node[arr][prevIndex];
+	if (currentBlock.type !== 'paragraph' || prevBlock.type !== 'paragraph') return false;
+	
+	// Join content
+	const joinedContent = prevBlock.content + currentBlock.content;
+	prevBlock.content = joinedContent;
+	prevBlock.last_modified = new Date().toISOString();
+	
+	// Remove current block
+	node[arr].splice(currentIndex, 1);
+	node.last_modified = new Date().toISOString();
+	
+	// Focus previous block at join point
+	const cursorPosition = prevBlock.content.length
+	EditorFocusService.focus(prevId, document, cursorPosition);
+	
+	return true;
+}
+
 export async function splitParagraph(
 	node: Section,
 	arr: 'summary' | 'children',

--- a/src/lib/view/collection/section-container/Default/Default.svelte
+++ b/src/lib/view/collection/section-container/Default/Default.svelte
@@ -52,7 +52,7 @@
 	onmouseleave={() => (isDefaultHovered = false)}
 >
 	{console.log('children renderers length in section container: ', ChildrenRenderers.length)}
-	{#each ChildrenRenderers as { Renderer }, index}
+	{#each ChildrenRenderers as { Renderer }, index (node.children[index].last_modified + node.children[index].id)}
 		<Renderer
 			path={[...path, 'children', index]}
 			{refs}

--- a/src/lib/view/collection/section/write/Write.svelte
+++ b/src/lib/view/collection/section/write/Write.svelte
@@ -11,7 +11,8 @@
 		handleHeadingLevelDecrease,
 		splitParagraph,
 		splitSection,
-		handleEnterInHeading
+		handleEnterInHeading,
+		joinWithPreviousParagraph
 	} from '$lib/actions/collection/section.svelte';
 	import Write from '$lib/view/collection/section-container/Write.svelte';
 	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
@@ -65,7 +66,8 @@
 				refs: Refs;
 				onUnmount: () => void;
 				onSplit: (newBlocks: [string, string]) => void;
-				onConvertToHeading: (paragraphId: string) => void;
+				onJoinWithPrevious?: () => boolean;
+				onConvertToHeading?: (paragraphId: string) => void;
 			}>
 		}))
 	);
@@ -76,6 +78,7 @@
 				refs: Refs;
 				onUnmount: () => void;
 				onSplit: (newBlocks: [string, string]) => void;
+				onJoinWithPrevious?: () => boolean;
 			}>
 		}))
 	);
@@ -137,6 +140,21 @@
 						onSplit={(newBlocks) => {
 							splitParagraph(node, 'summary', newBlocks, document, i);
 						}}
+						onJoinWithPrevious={() => {
+							if (i === 0) return false; // First paragraph can't join with previous
+							
+							// Get the previous block ID
+							const prevId = node.summary[i-1].id;
+							
+							// Join with previous paragraph
+							return joinWithPreviousParagraph(
+								node,
+								'summary',
+								i,
+								document,
+								prevId
+							);
+						}}
 						{onUnmount}
 					/>
 				{/each}
@@ -155,6 +173,22 @@
 							console.log('newBlocks');
 							console.log(newBlocks);
 							splitParagraph(node, 'children', newBlocks, document, i);
+						}}
+						onJoinWithPrevious={() => {
+							if (i === 0) return false; // First paragraph can't join with previous
+							
+							// Get the previous block ID
+							const prevId = node.children[i-1].id;
+							if (!prevId) return false;
+							
+							// Join with previous paragraph
+							return joinWithPreviousParagraph(
+								node,
+								'children',
+								i,
+								document,
+								prevId
+							);
 						}}
 						onConvertToHeading={(paragraphId) => {
 							splitSection(node, paragraphId, document, addSection);

--- a/src/lib/view/content/paragraph/Paragraph.svelte
+++ b/src/lib/view/content/paragraph/Paragraph.svelte
@@ -128,8 +128,6 @@
 			},
 			dispatchTransaction(transaction) {
 				const newState = view.state.apply(transaction);
-				console.log('transaction steps:');
-				console.log(transaction.steps);
 				onUnmount();
 
 				// console.log("enter pressed state:");
@@ -146,7 +144,10 @@
 				}
 
 				documentNode.state.animateNextChange = false;
-				node.content = defaultMarkdownSerializer.serialize(newState.doc);
+
+                if (transaction.docChanged) {
+                    node.content = defaultMarkdownSerializer.serialize(newState.doc);
+                }
 
 				view.updateState(newState);
 			},

--- a/src/lib/view/content/paragraph/backspacePlugin.ts
+++ b/src/lib/view/content/paragraph/backspacePlugin.ts
@@ -1,0 +1,28 @@
+import { keymap } from 'prosemirror-keymap';
+import type { Plugin } from 'prosemirror-state';
+
+/**
+ * Creates a ProseMirror plugin for handling backspace key at the start of content
+ * to join with the previous block
+ *
+ * @param onJoinWithPrevious Callback function to handle joining with previous block
+ * @returns A ProseMirror plugin for handling backspace at start
+ */
+export function createBackspacePlugin(
+	onJoinWithPrevious: () => boolean
+): Plugin {
+	return keymap({
+		Backspace: (state) => {
+			// Check if cursor is at the beginning of content
+			const { selection } = state;
+			const atStart = selection.$head.pos === 1;
+
+			if (atStart) {
+				console.log('Backspace at start of content');
+				// Call the join callback
+				return onJoinWithPrevious();
+			}
+			return false;
+		}
+	});
+}


### PR DESCRIPTION
made it so that when you press delete at the start of a paragraph, it gets joined to the previous one.

<img width="1182" alt="Screenshot 2025-04-09 at 19 28 23" src="https://github.com/user-attachments/assets/bb8e8129-25ca-42bb-9f23-0098f4c6ea75" />
<img width="1184" alt="Screenshot 2025-04-09 at 19 28 52" src="https://github.com/user-attachments/assets/c4e76e50-10f1-4d42-9612-7166fb389600" />

There is a problem with the cursor not updating to the right place, but the functionalities are there
