### PR TITLE
kill the animation

### DIFF
--- a/src/lib/components/Document.svelte
+++ b/src/lib/components/Document.svelte
@@ -44,57 +44,57 @@
 	const isDocumentViewPage = $derived(!!page.params.username && !!page.params.slug);
 
 	const onUnmount = () => {
-		const elements = Object.values(refs)
-			.filter((ref) => ref.element)
-			.map((ref) => ref.element);
-		flipState = Flip.getState(elements, {
-            props: "fontSize,lineHeight"
-        });
+		// const elements = Object.values(refs)
+		// 	.filter((ref) => ref.element)
+		// 	.map((ref) => ref.element);
+		// flipState = Flip.getState(elements, {
+        //     props: "fontSize,lineHeight"
+        // });
 	};
 
-	$effect(() => {
-		if (flipState !== null && node.state.animateNextChange) {
-			const elements = Object.values(refs).map(ref => ref.element);
+	// $effect(() => {
+	// 	if (flipState !== null && node.state.animateNextChange) {
+	// 		const elements = Object.values(refs).map(ref => ref.element);
 			
-			Flip.from(flipState as Flip.FlipState, {
-				targets: elements,
-				duration: 0.2,
-				delay: 0.2,
-				ease: 'power4.inOut',
-				absolute: false,
-				nested: false,
-				onStart: () => {
-					elements.forEach((element: HTMLElement) => {
-						element.style.pointerEvents = 'none';
-					});
-				},
-				onComplete: () => {
-					elements.forEach((element: HTMLElement) => {
-						element.style.pointerEvents = 'auto';
-					});
-				},
+	// 		Flip.from(flipState as Flip.FlipState, {
+	// 			targets: elements,
+	// 			duration: 0.2,
+	// 			delay: 0.2,
+	// 			ease: 'power4.inOut',
+	// 			absolute: false,
+	// 			nested: false,
+	// 			onStart: () => {
+	// 				elements.forEach((element: HTMLElement) => {
+	// 					element.style.pointerEvents = 'none';
+	// 				});
+	// 			},
+	// 			onComplete: () => {
+	// 				elements.forEach((element: HTMLElement) => {
+	// 					element.style.pointerEvents = 'auto';
+	// 				});
+	// 			},
 
-				onLeave: (elements) => {
-					gsap.fromTo(
-						elements,
-						{ opacity: 1 },
-						{ opacity: 0, duration: 0.2, ease: 'power4.inOut' }
-					);
-				},
+	// 			onLeave: (elements) => {
+	// 				gsap.fromTo(
+	// 					elements,
+	// 					{ opacity: 1 },
+	// 					{ opacity: 0, duration: 0.2, ease: 'power4.inOut' }
+	// 				);
+	// 			},
 
-				onEnter: (elements) => {
-					gsap.fromTo(
-						elements,
-						{ opacity: 0 },
-						{ opacity: 1, duration: 0.2, delay: 0.4, ease: 'power4.inOut' }
-					);
-				}
-			});
-		} else {
-			node.state.animateNextChange = true;
-			flipState = null;
-		}
-	});
+	// 			onEnter: (elements) => {
+	// 				gsap.fromTo(
+	// 					elements,
+	// 					{ opacity: 0 },
+	// 					{ opacity: 1, duration: 0.2, delay: 0.4, ease: 'power4.inOut' }
+	// 				);
+	// 			}
+	// 		});
+	// 	} else {
+	// 		node.state.animateNextChange = true;
+	// 		flipState = null;
+	// 	}
+	// });
 
 	$inspect(node);
 </script>


### PR DESCRIPTION
so the core of the animation logic is in Document.svelte, and mostly done by GSAP.

However, the presence of animation adds a layer of complexity when problems occur. We can't be sure whether it is truly the application logic, or GSAP's FLIP plugin that's acting up. And when it breaks, the whole thing just doesn't work and the whole experience get degraded. This is also on top of the fact that the animation makes thing not instant and snappy, because there is like a duration needed for the animation to run.

The reality is the place where animation would improve the user experience is when things move around. Animation here really elevates the experience, to which there occurs a lot. 

But as much as I believe that is important, we need to fix the core problem first, so I am disabling this to have less layers of problems until I get the shit up and running well.