### PR TITLE
make switching between card variations work

### DIFF
--- a/src/lib/actions/collection/section-container.svelte.ts
+++ b/src/lib/actions/collection/section-container.svelte.ts
@@ -104,14 +104,21 @@ export function createSectionContainer(): SectionContainer {
 		view: [
 			{ type: 'collection/section-container/default' },
 			{ type: 'collection/section-container/static' },
-			{ type: 'collection/section-container/card', state: {  gap: 16 } },
-			{ type: 'collection/section-container/brick' },
-			{ type: 'collection/section-container/table-of-contents', state: { directions: [] } },
+			{ type: 'collection/section-container/card', state: { gap: 16, variation: 'default' } },
+			{
+				type: 'collection/section-container/table-of-contents',
+				state: {
+					directions: []
+				}
+			},
 			{
 				type: 'collection/section-container/sidebar',
 				state: { percentageWidth: 30, activeIndex: 0 }
 			},
-			{ type: 'collection/section-container/tabs', state: { gap: 16, activeIndex: 0 } }
+			{
+				type: 'collection/section-container/tabs',
+				state: { gap: 16, activeIndex: 0 }
+			}
 		],
 		activeView: 'collection/section-container/default'
 	};

--- a/src/lib/actions/collection/section-container.svelte.ts
+++ b/src/lib/actions/collection/section-container.svelte.ts
@@ -106,7 +106,7 @@ export function createSectionContainer(): SectionContainer {
 		view: [
 			{ type: 'collection/section-container/default' },
 			{ type: 'collection/section-container/static' },
-			{ type: 'collection/section-container/card', state: { gap: 16, variation: 'default' } },
+			{ type: 'collection/section-container/card', state: { variation: 'default' } },
 			{
 				type: 'collection/section-container/table-of-contents',
 				state: {

--- a/src/lib/actions/collection/section-container.svelte.ts
+++ b/src/lib/actions/collection/section-container.svelte.ts
@@ -2,54 +2,56 @@ import type { Section, SectionContainer } from '$lib/model/collection';
 
 /**
  * Moves siblings after a section to be children of that section
- * 
+ *
  * @param container The section container
  * @param sectionId The ID of the section
  * @returns The siblings that were moved
  */
 export function moveSiblingsToSection(container: SectionContainer, sectionId: string): Section[] {
-	const sectionIndex = container.children.findIndex(child => child.id === sectionId);
+	const sectionIndex = container.children.findIndex((child) => child.id === sectionId);
 	if (sectionIndex === -1) return [];
-	
+
 	const section = container.children[sectionIndex];
 	const siblingsAfter = container.children.slice(sectionIndex + 1);
-	
+
 	// Find or create a section container in the section's children
-	let sectionContainerIndex = section.children.findIndex(child => child.type === 'section-container');
-	
+	let sectionContainerIndex = section.children.findIndex(
+		(child) => child.type === 'section-container'
+	);
+
 	if (sectionContainerIndex === -1) {
 		// Create a new section container and add it to the section's children
 		const newContainer = createSectionContainer();
 		section.children.push(newContainer);
 		sectionContainerIndex = section.children.length - 1;
 	}
-	
+
 	// Add siblings to the container by directly accessing it through the section's children
 	for (const sibling of siblingsAfter) {
 		(section.children[sectionContainerIndex] as SectionContainer).children.push(sibling);
 	}
-	
+
 	// Remove siblings from original container
 	container.children.splice(sectionIndex + 1, siblingsAfter.length);
 	container.last_modified = new Date().toISOString();
 	section.last_modified = new Date().toISOString();
-	
+
 	return siblingsAfter;
 }
 
 /**
  * Adds a section to a container after a specified section
- * 
+ *
  * @param container The section container
  * @param section The section to add
  * @param afterSectionId The ID of the section to add after
  */
 export function addSectionAfter(
-	container: SectionContainer, 
-	section: Section, 
+	container: SectionContainer,
+	section: Section,
 	afterSectionId: string
 ) {
-	const afterIndex = container.children.findIndex(child => child.id === afterSectionId);
+	const afterIndex = container.children.findIndex((child) => child.id === afterSectionId);
 	if (afterIndex !== -1) {
 		container.children.splice(afterIndex + 1, 0, section);
 		container.last_modified = new Date().toISOString();
@@ -131,14 +133,18 @@ export function createSectionContainer(): SectionContainer {
  * @param headingLevel
  * @returns
  */
-export function addSection(node: SectionContainer, headingLevel: number = 1) {
+export function addSection(
+	node: SectionContainer,
+	headingLevel: number = 1,
+	defaultState: 'expanded' | 'summary' = 'expanded'
+) {
 	node.children.push({
 		type: 'section',
 		id: crypto.randomUUID(),
 		created: new Date().toISOString(),
 		last_modified: new Date().toISOString(),
 		view: [
-			{ type: 'collection/section/default', state: 'expanded' },
+			{ type: 'collection/section/default', state: defaultState },
 			{ type: 'collection/section/static' },
 			{ type: 'collection/section/page' }
 		],

--- a/src/lib/model/collection.ts
+++ b/src/lib/model/collection.ts
@@ -99,7 +99,8 @@ export const untitledSection: z.ZodType<UntitledSection> = untitledSectionBase.e
 
 // Define a new type for the view state with constraints
 export const sectionContainerCardViewState = z.object({
-	gap: z.number().int().min(0).max(36)
+	gap: z.number().int().min(0).max(36),
+	variation: z.enum(['default', 'brick'])
 });
 
 export const sectionContainerTabsViewState = z.object({
@@ -125,9 +126,6 @@ const sectionContainerView = z.tuple([
 	z.object({
 		type: z.literal('collection/section-container/card'),
 		state: sectionContainerCardViewState
-	}),
-	z.object({
-		type: z.literal('collection/section-container/brick')
 	}),
 	z.object({
 		type: z.literal('collection/section-container/table-of-contents'),

--- a/src/lib/model/collection.ts
+++ b/src/lib/model/collection.ts
@@ -99,7 +99,6 @@ export const untitledSection: z.ZodType<UntitledSection> = untitledSectionBase.e
 
 // Define a new type for the view state with constraints
 export const sectionContainerCardViewState = z.object({
-	gap: z.number().int().min(0).max(36),
 	variation: z.enum(['default', 'brick'])
 });
 

--- a/src/lib/model/examples.ts
+++ b/src/lib/model/examples.ts
@@ -91,8 +91,7 @@ export const nested: Document = {
 		view: [
 			{ type: 'collection/section-container/default' },
 			{ type: 'collection/section-container/static' },
-			{ type: 'collection/section-container/card', state: { gap: 4 } },
-			{ type: 'collection/section-container/brick' },
+			{ type: 'collection/section-container/card', state: { gap: 4, variation: 'default' } },
 			{
 				type: 'collection/section-container/table-of-contents',
 				state: {
@@ -312,8 +311,7 @@ export const card: Document = {
 		view: [
 			{ type: 'collection/section-container/default' },
 			{ type: 'collection/section-container/static' },
-			{ type: 'collection/section-container/card', state: { gap: 16 } },
-			{ type: 'collection/section-container/brick' },
+			{ type: 'collection/section-container/card', state: { gap: 16, variation: 'default' } },
 			{
 				type: 'collection/section-container/table-of-contents',
 				state: {
@@ -586,8 +584,7 @@ const nestedSectionContainer: (num: number) => z.infer<typeof sectionContainer> 
 	view: [
 		{ type: 'collection/section-container/default' },
 		{ type: 'collection/section-container/static' },
-		{ type: 'collection/section-container/card', state: { gap: 4 } },
-		{ type: 'collection/section-container/brick' },
+		{ type: 'collection/section-container/card', state: { gap: 4, variation: 'default' } },
 		{
 			type: 'collection/section-container/table-of-contents',
 			state: {
@@ -614,7 +611,10 @@ const nestedSectionContainer: (num: number) => z.infer<typeof sectionContainer> 
 			type: 'collection/section-container/sidebar',
 			state: { percentageWidth: 30, activeIndex: 0 }
 		},
-		{ type: 'collection/section-container/tabs', state: { gap: 16, activeIndex: 0 } }
+		{
+			type: 'collection/section-container/tabs',
+			state: { gap: 16, activeIndex: 0 }
+		}
 	],
 	activeView: 'collection/section-container/default',
 	children: [
@@ -687,8 +687,7 @@ export const sectionContainerTOC: Document = {
 		view: [
 			{ type: 'collection/section-container/default' },
 			{ type: 'collection/section-container/static' },
-			{ type: 'collection/section-container/card', state: {  gap: 4 } },
-			{ type: 'collection/section-container/brick' },
+			{ type: 'collection/section-container/card', state: { gap: 4, variation: 'default' } },
 			{
 				type: 'collection/section-container/table-of-contents',
 				state: {
@@ -744,8 +743,7 @@ export const sectionContainerDefault: Document = {
 		view: [
 			{ type: 'collection/section-container/default' },
 			{ type: 'collection/section-container/static' },
-			{ type: 'collection/section-container/card', state: { gap: 4 } },
-			{ type: 'collection/section-container/brick' },
+			{ type: 'collection/section-container/card', state: { gap: 4, variation: 'default' } },
 			{
 				type: 'collection/section-container/table-of-contents',
 				state: {
@@ -802,8 +800,7 @@ export const sectionContainerTOCCard: Document = {
 		view: [
 			{ type: 'collection/section-container/default' },
 			{ type: 'collection/section-container/static' },
-			{ type: 'collection/section-container/card', state: { gap: 4 } },
-			{ type: 'collection/section-container/brick' },
+			{ type: 'collection/section-container/card', state: { gap: 4, variation: 'default' } },
 			{
 				type: 'collection/section-container/table-of-contents',
 				state: {
@@ -848,8 +845,7 @@ export const sidebarExample: SectionContainer = {
 	view: [
 		{ type: 'collection/section-container/default' },
 		{ type: 'collection/section-container/static' },
-		{ type: 'collection/section-container/card', state: {  gap: 4 } },
-		{ type: 'collection/section-container/brick' },
+		{ type: 'collection/section-container/card', state: {  gap: 4, variation: "default" } },
 		{ type: 'collection/section-container/table-of-contents', state: { directions: [] } },
 		{
 			type: 'collection/section-container/sidebar',

--- a/src/lib/model/examples.ts
+++ b/src/lib/model/examples.ts
@@ -91,7 +91,7 @@ export const nested: Document = {
 		view: [
 			{ type: 'collection/section-container/default' },
 			{ type: 'collection/section-container/static' },
-			{ type: 'collection/section-container/card', state: { gap: 4, variation: 'default' } },
+			{ type: 'collection/section-container/card', state: {  variation: 'default' } },
 			{
 				type: 'collection/section-container/table-of-contents',
 				state: {
@@ -311,7 +311,7 @@ export const card: Document = {
 		view: [
 			{ type: 'collection/section-container/default' },
 			{ type: 'collection/section-container/static' },
-			{ type: 'collection/section-container/card', state: { gap: 16, variation: 'default' } },
+			{ type: 'collection/section-container/card', state: {  variation: 'default' } },
 			{
 				type: 'collection/section-container/table-of-contents',
 				state: {
@@ -584,7 +584,7 @@ const nestedSectionContainer: (num: number) => z.infer<typeof sectionContainer> 
 	view: [
 		{ type: 'collection/section-container/default' },
 		{ type: 'collection/section-container/static' },
-		{ type: 'collection/section-container/card', state: { gap: 4, variation: 'default' } },
+		{ type: 'collection/section-container/card', state: { variation: 'default' } },
 		{
 			type: 'collection/section-container/table-of-contents',
 			state: {
@@ -687,7 +687,7 @@ export const sectionContainerTOC: Document = {
 		view: [
 			{ type: 'collection/section-container/default' },
 			{ type: 'collection/section-container/static' },
-			{ type: 'collection/section-container/card', state: { gap: 4, variation: 'default' } },
+			{ type: 'collection/section-container/card', state: { variation: 'default' } },
 			{
 				type: 'collection/section-container/table-of-contents',
 				state: {
@@ -743,7 +743,7 @@ export const sectionContainerDefault: Document = {
 		view: [
 			{ type: 'collection/section-container/default' },
 			{ type: 'collection/section-container/static' },
-			{ type: 'collection/section-container/card', state: { gap: 4, variation: 'default' } },
+			{ type: 'collection/section-container/card', state: { variation: 'default' } },
 			{
 				type: 'collection/section-container/table-of-contents',
 				state: {
@@ -800,7 +800,7 @@ export const sectionContainerTOCCard: Document = {
 		view: [
 			{ type: 'collection/section-container/default' },
 			{ type: 'collection/section-container/static' },
-			{ type: 'collection/section-container/card', state: { gap: 4, variation: 'default' } },
+			{ type: 'collection/section-container/card', state: { variation: 'default' } },
 			{
 				type: 'collection/section-container/table-of-contents',
 				state: {
@@ -845,7 +845,7 @@ export const sidebarExample: SectionContainer = {
 	view: [
 		{ type: 'collection/section-container/default' },
 		{ type: 'collection/section-container/static' },
-		{ type: 'collection/section-container/card', state: {  gap: 4, variation: "default" } },
+		{ type: 'collection/section-container/card', state: {  variation: "default" } },
 		{ type: 'collection/section-container/table-of-contents', state: { directions: [] } },
 		{
 			type: 'collection/section-container/sidebar',

--- a/src/lib/view/collection/section-container/Card/Brick.svelte
+++ b/src/lib/view/collection/section-container/Card/Brick.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+	import {
+		sectionContainer,
+		sectionContainerCardViewState,
+		type Section
+	} from '$lib/model/collection';
+	import type { ContentHeading, ContentParagraph } from '$lib/model/content';
+	import { registry } from '$lib/viewRegistry.svelte';
+	import type { Component } from 'svelte';
+	import type { z } from 'zod';
+	import type { Refs } from '$lib/components/Document.svelte';
+	import { getContext } from 'svelte';
+	import type { Document } from '$lib/model/document';
+	import { addSection } from '$lib/actions/collection/section-container.svelte';
+	import { createHeadingNavProps, createSummaryNavProps } from './navigation';
+	import type { NavigationHandler } from '$lib/services/navigation/types';
+	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
+	import Chip from '$lib/components/Chip.svelte';
+
+	// Custom action to bind an element to refs with a specific ID
+	function bindToRefs(element: HTMLElement, id: string) {
+		// Set the data-flip-id attribute
+		element.setAttribute('data-flip-id', id);
+
+		// Add the element to the refs object
+		refs[id] = { element };
+
+		// Return a cleanup function
+		return {
+			destroy() {
+				// Remove the element from refs when unmounted
+				delete refs[id];
+			}
+		};
+	}
+
+	const document = getContext('document') as Document;
+	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
+
+	type SectionContainer = z.infer<typeof sectionContainer>;
+	type SectionContainerViewState = z.infer<typeof sectionContainerCardViewState>;
+
+	// Define component types with navigation props
+	type HeadingComponentProps = {
+		path: (string | number)[];
+		refs: Refs;
+		onUnmount: () => void;
+		updateParent?: () => void;
+		getNextEditable?: NavigationHandler;
+		getPrevEditable?: NavigationHandler;
+		overrides?: {
+			class?: string;
+		};
+		onClickReadMode?: () => void;
+		documentNode?: Document;
+	};
+
+	type ContentComponentProps = {
+		path: (string | number)[];
+		refs: Refs;
+		onUnmount: () => void;
+		overrides?: {
+			class?: string;
+		};
+		updateParent?: () => void;
+		onSplit?: (blocks: [string, string]) => void;
+		getNextEditable?: NavigationHandler;
+		getPrevEditable?: NavigationHandler;
+		documentNode?: Document;
+	};
+
+	let {
+		path,
+		refs,
+		onUnmount,
+		onHeadingClick
+	}: {
+		path: (string | number)[];
+		refs: Refs;
+		onUnmount: () => void;
+		onHeadingClick?: (section: Section) => void;
+	} = $props();
+
+	const node = documentManipulator.getByPath(path) as SectionContainer;
+	let { children, view, activeView } = $derived(node);
+
+	let SectionRenderers = $derived(
+		children.map((child, sectionIndex) => ({
+			child,
+			sectionIndex,
+			HeadingRenderer: registry[
+				child.heading.activeView as keyof typeof registry
+			] as unknown as Component<HeadingComponentProps>,
+			SummaryRenderers: child.summary.map((summaryChild, summaryIndex) => ({
+				summaryChild,
+				summaryIndex,
+				Renderer: registry[
+					summaryChild.activeView as keyof typeof registry
+				] as unknown as Component<ContentComponentProps>
+			}))
+		}))
+	);
+
+	let someHasImage = $derived(children.some((child) => child.image));
+
+	let gap = $derived(
+		(view.find((v) => v.type === activeView) as { state: SectionContainerViewState }).state.gap
+	);
+
+	// Minimum width for cards
+	const minCardWidth = 250;
+</script>
+
+<div class="card-container" style:--gap={`${gap}px`} style:--min-card-width={`${minCardWidth}px`}>
+	{#each SectionRenderers as { child, sectionIndex, HeadingRenderer, SummaryRenderers }}
+		<div class="card flex flex-row gap-6 border-1 border-gray-400 p-5">
+			{#if child.image}
+				<img
+					class="w-24 h-24 xl:w-32 xl:h-32"
+					src={child.image}
+					alt="Section cover"
+					use:bindToRefs={`${child.id}-image`}
+				/>
+			{:else if someHasImage}
+				<div class="w-24 h-24 xl:w-32 xl:h-32" />
+			{/if}
+			<div class="flex flex-col gap-2 xl:gap-2">
+				<HeadingRenderer
+					path={[...path, 'children', sectionIndex, 'heading']}
+					{refs}
+					{onUnmount}
+					{...createHeadingNavProps(child, node, sectionIndex, document)}
+					overrides={{
+						class: 'prose-h1:text-xl'
+					}}
+					onClickReadMode={() => {
+						// toggle the state in the default view, not change it to the default view. Change the state in the default view.
+						const defaultView = node.children[sectionIndex].view.find(
+							(v) => v.type === 'collection/section/default'
+						);
+						if (defaultView) {
+							document.state.animateNextChange = true;
+							onUnmount();
+							defaultView.state = defaultView.state === 'expanded' ? 'summary' : 'expanded';
+						}
+						if (onHeadingClick) {
+							onHeadingClick(child);
+						}
+					}}
+				/>
+				<div>
+					{#each SummaryRenderers as { summaryChild, summaryIndex, Renderer }}
+						<Renderer
+							path={[...path, 'children', sectionIndex, 'summary', summaryIndex]}
+							{refs}
+							{onUnmount}
+							overrides={{
+								class: 'prose-p:text-xs prose-p:text-gray-500'
+							}}
+							{...createSummaryNavProps(child, node, summaryChild.id, sectionIndex, document)}
+						/>
+					{/each}
+				</div>
+			</div>
+		</div>
+	{/each}
+
+	{#if document.state.mode !== 'read'}
+		<Chip
+			onclick={() => {
+				onUnmount();
+				addSection(node, node.children[0].heading.level);
+			}}
+			label="Add Section"
+		/>
+	{/if}
+</div>
+
+<style lang="postcss">
+	.card-container {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: var(--gap);
+	}
+
+	@media (min-width: 1280px) {
+		.card-container {
+			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+</style>

--- a/src/lib/view/collection/section-container/Card/Brick.svelte
+++ b/src/lib/view/collection/section-container/Card/Brick.svelte
@@ -16,6 +16,7 @@
 	import type { NavigationHandler } from '$lib/services/navigation/types';
 	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
 	import Chip from '$lib/components/Chip.svelte';
+	import { handleReadModeToggle, handleAddSection, type HeadingComponentProps, type ContentComponentProps, type SectionContainerType, type SectionContainerViewStateType } from './cardUtils';
 
 	// Custom action to bind an element to refs with a specific ID
 	function bindToRefs(element: HTMLElement, id: string) {
@@ -37,37 +38,6 @@
 	const document = getContext('document') as Document;
 	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
 
-	type SectionContainer = z.infer<typeof sectionContainer>;
-	type SectionContainerViewState = z.infer<typeof sectionContainerCardViewState>;
-
-	// Define component types with navigation props
-	type HeadingComponentProps = {
-		path: (string | number)[];
-		refs: Refs;
-		onUnmount: () => void;
-		updateParent?: () => void;
-		getNextEditable?: NavigationHandler;
-		getPrevEditable?: NavigationHandler;
-		overrides?: {
-			class?: string;
-		};
-		onClickReadMode?: () => void;
-		documentNode?: Document;
-	};
-
-	type ContentComponentProps = {
-		path: (string | number)[];
-		refs: Refs;
-		onUnmount: () => void;
-		overrides?: {
-			class?: string;
-		};
-		updateParent?: () => void;
-		onSplit?: (blocks: [string, string]) => void;
-		getNextEditable?: NavigationHandler;
-		getPrevEditable?: NavigationHandler;
-		documentNode?: Document;
-	};
 
 	let {
 		path,
@@ -79,7 +49,7 @@
 		onUnmount: () => void;
 	} = $props();
 
-	const node = documentManipulator.getByPath(path) as SectionContainer;
+	const node = documentManipulator.getByPath(path) as SectionContainerType;
 	let { children, view, activeView } = $derived(node);
 
 	let SectionRenderers = $derived(
@@ -101,26 +71,22 @@
 
 	let someHasImage = $derived(children.some((child) => child.image));
 
-	let gap = $derived(
-		(view.find((v) => v.type === activeView) as { state: SectionContainerViewState }).state.gap
-	);
-
 	// Minimum width for cards
 	const minCardWidth = 250;
 </script>
 
-<div class="card-container" style:--gap={`${gap}px`} style:--min-card-width={`${minCardWidth}px`}>
+<div class="card-container"  style:--min-card-width={`${minCardWidth}px`}>
 	{#each SectionRenderers as { child, sectionIndex, HeadingRenderer, SummaryRenderers }}
 		<div class="card flex flex-row gap-6 border-1 border-gray-400 p-5">
 			{#if child.image}
 				<img
-					class="w-24 h-24 xl:w-32 xl:h-32"
+					class="h-24 w-24 xl:h-32 xl:w-32"
 					src={child.image}
 					alt="Section cover"
 					use:bindToRefs={`${child.id}-image`}
 				/>
 			{:else if someHasImage}
-				<div class="w-24 shrink-0 h-24 xl:w-32 xl:h-32" />
+				<div class="h-24 w-24 shrink-0 xl:h-32 xl:w-32" />
 			{/if}
 			<div class="flex flex-col gap-2 xl:gap-2">
 				<HeadingRenderer
@@ -131,17 +97,7 @@
 					overrides={{
 						class: 'prose-h1:text-xl'
 					}}
-					onClickReadMode={() => {
-						// toggle the state in the default view, not change it to the default view. Change the state in the default view.
-						const defaultView = node.children[sectionIndex].view.find(
-							(v) => v.type === 'collection/section/default'
-						);
-						if (defaultView) {
-							document.state.animateNextChange = true;
-							onUnmount();
-							defaultView.state = defaultView.state === 'expanded' ? 'summary' : 'expanded';
-						}
-					}}
+					onClickReadMode={() => handleReadModeToggle(sectionIndex, node, document, onUnmount)}
 				/>
 				<div>
 					{#each SummaryRenderers as { summaryChild, summaryIndex, Renderer }}
@@ -162,10 +118,7 @@
 
 	{#if document.state.mode !== 'read'}
 		<Chip
-			onclick={() => {
-				onUnmount();
-				addSection(node, node.children[0].heading.level, "summary");
-			}}
+			onclick={() => handleAddSection(node, onUnmount)}
 			label="Add Section"
 		/>
 	{/if}
@@ -175,7 +128,7 @@
 	.card-container {
 		display: grid;
 		grid-template-columns: 1fr;
-		gap: var(--gap);
+        gap: 16px;
 	}
 
 	@media (min-width: 1280px) {

--- a/src/lib/view/collection/section-container/Card/Brick.svelte
+++ b/src/lib/view/collection/section-container/Card/Brick.svelte
@@ -73,12 +73,10 @@
 		path,
 		refs,
 		onUnmount,
-		onHeadingClick
 	}: {
 		path: (string | number)[];
 		refs: Refs;
 		onUnmount: () => void;
-		onHeadingClick?: (section: Section) => void;
 	} = $props();
 
 	const node = documentManipulator.getByPath(path) as SectionContainer;
@@ -122,7 +120,7 @@
 					use:bindToRefs={`${child.id}-image`}
 				/>
 			{:else if someHasImage}
-				<div class="w-24 h-24 xl:w-32 xl:h-32" />
+				<div class="w-24 shrink-0 h-24 xl:w-32 xl:h-32" />
 			{/if}
 			<div class="flex flex-col gap-2 xl:gap-2">
 				<HeadingRenderer
@@ -142,9 +140,6 @@
 							document.state.animateNextChange = true;
 							onUnmount();
 							defaultView.state = defaultView.state === 'expanded' ? 'summary' : 'expanded';
-						}
-						if (onHeadingClick) {
-							onHeadingClick(child);
 						}
 					}}
 				/>
@@ -169,7 +164,7 @@
 		<Chip
 			onclick={() => {
 				onUnmount();
-				addSection(node, node.children[0].heading.level);
+				addSection(node, node.children[0].heading.level, "summary");
 			}}
 			label="Add Section"
 		/>

--- a/src/lib/view/collection/section-container/Card/Card.svelte
+++ b/src/lib/view/collection/section-container/Card/Card.svelte
@@ -9,6 +9,7 @@
 	import type { Document } from '$lib/model/document';
 	import Controls from './Controls.svelte';
 	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
+    import DefaultView from "$lib/view/collection/section-container/Default/Default.svelte"
 	import Default from './Default.svelte';
 	import Brick from './Brick.svelte';
 	import type { z } from 'zod';
@@ -42,21 +43,6 @@
 		isCardHovered = false;
 	}
 
-	//** if the heading is clicked, and the section is the only expanded section in the container, animate the change. */
-	function onHeadingClick(section: Section) {
-		const defaultView = section.view.find((v) => v.type === 'collection/section/default');
-		if (defaultView?.state === 'expanded') {
-			const expandedSections = children.filter((s) => {
-				const view = s.view.find((v) => v.type === 'collection/section/default');
-				return view?.state === 'expanded';
-			});
-
-			if (expandedSections.length === 1 && expandedSections[0].id === section.id) {
-				onUnmount();
-				document.state.animateNextChange = true;
-			}
-		}
-	}
 
 	// Get the current variation from the state
 	function getVariation() {
@@ -75,7 +61,7 @@
 	return defaultView?.state === 'summary';
 })}
 	<div class="card-container" onmouseenter={showCardControls} onmouseleave={hideCardControls}>
-		<Default {path} {refs} {onUnmount} {onHeadingClick} />
+		<DefaultView {path} {refs} {onUnmount}/>
 	</div>
 {:else}
 	<div class="card-container" onmouseenter={showCardControls} onmouseleave={hideCardControls}>
@@ -84,9 +70,9 @@
 		{/if}
 
 		{#if variation === 'brick'}
-			<Brick {path} {refs} {onUnmount} {onHeadingClick} />
+			<Brick {path} {refs} {onUnmount}/>
 		{:else}
-			<Default {path} {refs} {onUnmount} {onHeadingClick} />
+			<Default {path} {refs} {onUnmount} />
 		{/if}
 	</div>
 {/if}

--- a/src/lib/view/collection/section-container/Card/Card.svelte
+++ b/src/lib/view/collection/section-container/Card/Card.svelte
@@ -4,72 +4,14 @@
 		sectionContainerCardViewState,
 		type Section
 	} from '$lib/model/collection';
-	import type { ContentHeading, ContentParagraph } from '$lib/model/content';
-	import { registry } from '$lib/viewRegistry.svelte';
-	import type { Component } from 'svelte';
-	import type { z } from 'zod';
 	import type { Refs } from '$lib/components/Document.svelte';
-	import { getContext, onDestroy } from 'svelte';
+	import { getContext } from 'svelte';
 	import type { Document } from '$lib/model/document';
 	import Controls from './Controls.svelte';
-	import { addSection } from '$lib/actions/collection/section-container.svelte';
-	import { createHeadingNavProps, createSummaryNavProps } from './navigation';
-	import type { NavigationHandler } from '$lib/services/navigation/types';
 	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
-	import Chip from '$lib/components/Chip.svelte';
-	import Default from '../Default/Default.svelte';
-
-	// Custom action to bind an element to refs with a specific ID
-	function bindToRefs(element: HTMLElement, id: string) {
-		// Set the data-flip-id attribute
-		element.setAttribute('data-flip-id', id);
-		
-		// Add the element to the refs object
-		refs[id] = { element };
-		
-		// Return a cleanup function
-		return {
-			destroy() {
-				// Remove the element from refs when unmounted
-				delete refs[id];
-			}
-		};
-	}
-
-	const document = getContext('document') as Document;
-	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
-
-	type SectionContainer = z.infer<typeof sectionContainer>;
-	type SectionContainerViewState = z.infer<typeof sectionContainerCardViewState>;
-
-	// Define component types with navigation props
-	type HeadingComponentProps = {
-		path: (string | number)[];
-		refs: Refs;
-		onUnmount: () => void;
-		updateParent?: () => void;
-		getNextEditable?: NavigationHandler;
-		getPrevEditable?: NavigationHandler;
-		overrides?: {
-			class?: string;
-		};
-		onClickReadMode?: () => void;
-		documentNode?: Document;
-	};
-
-	type ContentComponentProps = {
-		path: (string | number)[];
-		refs: Refs;
-		onUnmount: () => void;
-		overrides?: {
-			class?: string;
-		};
-		updateParent?: () => void;
-		onSplit?: (blocks: [string, string]) => void;
-		getNextEditable?: NavigationHandler;
-		getPrevEditable?: NavigationHandler;
-		documentNode?: Document;
-	};
+	import Default from './Default.svelte';
+	import Brick from './Brick.svelte';
+	import type { z } from 'zod';
 
 	let {
 		path,
@@ -81,34 +23,14 @@
 		onUnmount: () => void;
 	} = $props();
 
+	const document = getContext('document') as Document;
+	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
+
+	type SectionContainer = z.infer<typeof sectionContainer>;
+	type SectionContainerViewState = z.infer<typeof sectionContainerCardViewState>;
+
 	const node = documentManipulator.getByPath(path) as SectionContainer;
 	let { children, view, activeView } = $derived(node);
-
-	let SectionRenderers = $derived(
-		children.map((child, sectionIndex) => ({
-			child,
-			sectionIndex,
-			HeadingRenderer: registry[
-				child.heading.activeView as keyof typeof registry
-			] as unknown as Component<HeadingComponentProps>,
-			SummaryRenderers: child.summary.map((summaryChild, summaryIndex) => ({
-				summaryChild,
-				summaryIndex,
-				Renderer: registry[
-					summaryChild.activeView as keyof typeof registry
-				] as unknown as Component<ContentComponentProps>
-			}))
-		}))
-	);
-
-	let someHasImage = $derived(children.some((child) => child.image));
-
-	let gap = $derived(
-		(view.find((v) => v.type === activeView) as { state: SectionContainerViewState }).state.gap
-	);
-
-	// Minimum width for cards
-	const minCardWidth = 250;
 
 	let isCardHovered = $state(false);
 
@@ -135,6 +57,17 @@
 			}
 		}
 	}
+
+	// Get the current variation from the state
+	function getVariation() {
+		const currentView = view.find((v) => v.type === activeView);
+		if (currentView && 'state' in currentView && currentView.state) {
+			return (currentView.state as SectionContainerViewState).variation ?? 'default';
+		}
+		return 'default';
+	}
+	
+	let variation = $derived(getVariation());
 </script>
 
 {#if !node.children.every((child) => {
@@ -150,80 +83,16 @@
 			<Controls {path} {onUnmount} {isCardHovered} />
 		{/if}
 
-		<div class="card-grid" style:--gap={`${gap}px`} style:--min-card-width={`${minCardWidth}px`}>
-			{#each SectionRenderers as { child, sectionIndex, HeadingRenderer, SummaryRenderers }}
-				<div class="card flex flex-col gap-6 border-1 border-gray-400 p-5">
-					{#if child.image}
-						<img 
-							class="aspect-square" 
-							src={child.image} 
-							alt="Section cover"
-							use:bindToRefs={`${child.id}-image`}
-						/>
-					{:else if someHasImage}
-						<div class="aspect-square" />
-					{/if}
-					<div>
-						<HeadingRenderer
-							path={[...path, 'children', sectionIndex, 'heading']}
-							{refs}
-							{onUnmount}
-							{...createHeadingNavProps(child, node, sectionIndex, document)}
-							overrides={{
-								class: 'prose-h1:text-xl'
-							}}
-							onClickReadMode={() => {
-								// toggle the state in the default view, not change it to the default view. Change the state in the default view.
-								const defaultView = node.children[sectionIndex].view.find(
-									(v) => v.type === 'collection/section/default'
-								);
-								if (defaultView) {
-									document.state.animateNextChange = true;
-									onUnmount();
-									defaultView.state = defaultView.state === 'expanded' ? 'summary' : 'expanded';
-								}
-							}}
-						/>
-						{#each SummaryRenderers as { summaryChild, summaryIndex, Renderer }}
-							<Renderer
-								path={[...path, 'children', sectionIndex, 'summary', summaryIndex]}
-								{refs}
-								{onUnmount}
-								overrides={{
-									class: 'prose-p:text-xs prose-p:text-gray-500'
-								}}
-								{...createSummaryNavProps(child, node, summaryChild.id, sectionIndex, document)}
-							/>
-						{/each}
-					</div>
-				</div>
-			{/each}
-
-			{#if document.state.mode !== 'read'}
-				<Chip
-					onclick={() => {
-						onUnmount();
-						addSection(node, node.children[0].heading.level);
-					}}
-					label="Add Section"
-				/>
-			{/if}
-		</div>
+		{#if variation === 'brick'}
+			<Brick {path} {refs} {onUnmount} {onHeadingClick} />
+		{:else}
+			<Default {path} {refs} {onUnmount} {onHeadingClick} />
+		{/if}
 	</div>
 {/if}
 
 <style lang="postcss">
 	.card-container {
 		position: relative;
-	}
-
-	.card-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(var(--min-card-width), 1fr));
-		gap: var(--gap);
-	}
-
-	.card {
-		min-width: var(--min-card-width);
 	}
 </style>

--- a/src/lib/view/collection/section-container/Card/Controls.svelte
+++ b/src/lib/view/collection/section-container/Card/Controls.svelte
@@ -3,6 +3,8 @@
 	import { float, calculateZIndex } from '$lib/view/utils/float.svelte';
 	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
 	import type { SectionContainer } from '$lib/model/collection';
+	import { sectionContainerCardViewState } from '$lib/model/collection';
+	import type { z } from 'zod';
 
 	let {
 		path,
@@ -16,6 +18,14 @@
 
 	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
 	const node = documentManipulator.getByPath(path) as SectionContainer;
+	
+	type CardViewState = z.infer<typeof sectionContainerCardViewState>;
+	
+	// Get the current view state
+	const activeView = node.activeView;
+	const currentView = node.view.find((v) => v.type === activeView);
+	const hasCardState = currentView && 'state' in currentView && currentView.state;
+	const viewState = hasCardState ? currentView.state as CardViewState : null;
 
 	let isHovered = $state(false);
 
@@ -33,6 +43,18 @@
 	function switchToDefault() {
 		onUnmount();
 		node.activeView = 'collection/section-container/default';
+	}
+	
+	function changeVariation(event: Event) {
+		const select = event.target as HTMLSelectElement;
+		const newVariation = select.value as 'default' | 'brick';
+		
+		onUnmount();
+		// Update the variation in the state
+		const viewToUpdate = node.view.find((v) => v.type === activeView);
+		if (viewToUpdate && 'state' in viewToUpdate && viewToUpdate.state) {
+			(viewToUpdate.state as CardViewState).variation = newVariation;
+		}
 	}
 
 	onMount(() => {
@@ -52,9 +74,22 @@
 		isHovered || isCardHovered ? 'visible' : 'invisible'
 	]}
 >
-	<button class="rounded-md bg-blue-500 p-2 text-white" onclick={switchToDefault}>
-		default
-	</button>
+	<div class="flex flex-col gap-2">
+		<button class="rounded-md bg-blue-500 p-2 text-white" onclick={switchToDefault}>
+			default
+		</button>
+		
+		<div class="flex flex-col">
+			<label for="variation-select" class="text-sm text-gray-700">Layout:</label>
+			<select 
+				value={viewState?.variation ?? 'default'}
+				onchange={changeVariation}
+			>
+				<option value="default">Default</option>
+				<option value="brick">Brick</option>
+			</select>
+		</div>
+	</div>
 </div>
 
 <div bind:this={referenceElement} class="reference-element w-full"></div>

--- a/src/lib/view/collection/section-container/Card/Default.svelte
+++ b/src/lib/view/collection/section-container/Card/Default.svelte
@@ -73,12 +73,10 @@
 		path,
 		refs,
 		onUnmount,
-		onHeadingClick
 	}: {
 		path: (string | number)[];
 		refs: Refs;
 		onUnmount: () => void;
-		onHeadingClick?: (section: Section) => void;
 	} = $props();
 
 	const node = documentManipulator.getByPath(path) as SectionContainer;
@@ -143,9 +141,6 @@
 							onUnmount();
 							defaultView.state = defaultView.state === 'expanded' ? 'summary' : 'expanded';
 						}
-						if (onHeadingClick) {
-							onHeadingClick(child);
-						}
 					}}
 				/>
 				{#each SummaryRenderers as { summaryChild, summaryIndex, Renderer }}
@@ -167,7 +162,7 @@
 		<Chip
 			onclick={() => {
 				onUnmount();
-				addSection(node, node.children[0].heading.level);
+				addSection(node, node.children[0].heading.level, "summary");
 			}}
 			label="Add Section"
 		/>

--- a/src/lib/view/collection/section-container/Card/Default.svelte
+++ b/src/lib/view/collection/section-container/Card/Default.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+	import {
+		sectionContainer,
+		sectionContainerCardViewState,
+		type Section
+	} from '$lib/model/collection';
+	import type { ContentHeading, ContentParagraph } from '$lib/model/content';
+	import { registry } from '$lib/viewRegistry.svelte';
+	import type { Component } from 'svelte';
+	import type { z } from 'zod';
+	import type { Refs } from '$lib/components/Document.svelte';
+	import { getContext } from 'svelte';
+	import type { Document } from '$lib/model/document';
+	import { addSection } from '$lib/actions/collection/section-container.svelte';
+	import { createHeadingNavProps, createSummaryNavProps } from './navigation';
+	import type { NavigationHandler } from '$lib/services/navigation/types';
+	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
+	import Chip from '$lib/components/Chip.svelte';
+
+	// Custom action to bind an element to refs with a specific ID
+	function bindToRefs(element: HTMLElement, id: string) {
+		// Set the data-flip-id attribute
+		element.setAttribute('data-flip-id', id);
+		
+		// Add the element to the refs object
+		refs[id] = { element };
+		
+		// Return a cleanup function
+		return {
+			destroy() {
+				// Remove the element from refs when unmounted
+				delete refs[id];
+			}
+		};
+	}
+
+	const document = getContext('document') as Document;
+	const documentManipulator = getContext('documentManipulator') as DocumentManipulator;
+
+	type SectionContainer = z.infer<typeof sectionContainer>;
+	type SectionContainerViewState = z.infer<typeof sectionContainerCardViewState>;
+
+	// Define component types with navigation props
+	type HeadingComponentProps = {
+		path: (string | number)[];
+		refs: Refs;
+		onUnmount: () => void;
+		updateParent?: () => void;
+		getNextEditable?: NavigationHandler;
+		getPrevEditable?: NavigationHandler;
+		overrides?: {
+			class?: string;
+		};
+		onClickReadMode?: () => void;
+		documentNode?: Document;
+	};
+
+	type ContentComponentProps = {
+		path: (string | number)[];
+		refs: Refs;
+		onUnmount: () => void;
+		overrides?: {
+			class?: string;
+		};
+		updateParent?: () => void;
+		onSplit?: (blocks: [string, string]) => void;
+		getNextEditable?: NavigationHandler;
+		getPrevEditable?: NavigationHandler;
+		documentNode?: Document;
+	};
+
+	let {
+		path,
+		refs,
+		onUnmount,
+		onHeadingClick
+	}: {
+		path: (string | number)[];
+		refs: Refs;
+		onUnmount: () => void;
+		onHeadingClick?: (section: Section) => void;
+	} = $props();
+
+	const node = documentManipulator.getByPath(path) as SectionContainer;
+	let { children, view, activeView } = $derived(node);
+
+	let SectionRenderers = $derived(
+		children.map((child, sectionIndex) => ({
+			child,
+			sectionIndex,
+			HeadingRenderer: registry[
+				child.heading.activeView as keyof typeof registry
+			] as unknown as Component<HeadingComponentProps>,
+			SummaryRenderers: child.summary.map((summaryChild, summaryIndex) => ({
+				summaryChild,
+				summaryIndex,
+				Renderer: registry[
+					summaryChild.activeView as keyof typeof registry
+				] as unknown as Component<ContentComponentProps>
+			}))
+		}))
+	);
+
+	let someHasImage = $derived(children.some((child) => child.image));
+
+	let gap = $derived(
+		(view.find((v) => v.type === activeView) as { state: SectionContainerViewState }).state.gap
+	);
+
+	// Minimum width for cards
+	const minCardWidth = 250;
+</script>
+
+<div class="card-grid" style:--gap={`${gap}px`} style:--min-card-width={`${minCardWidth}px`}>
+	{#each SectionRenderers as { child, sectionIndex, HeadingRenderer, SummaryRenderers }}
+		<div class="card flex flex-col gap-6 border-1 border-gray-400 p-5">
+			{#if child.image}
+				<img 
+					class="aspect-square" 
+					src={child.image} 
+					alt="Section cover"
+					use:bindToRefs={`${child.id}-image`}
+				/>
+			{:else if someHasImage}
+				<div class="aspect-square" />
+			{/if}
+			<div>
+				<HeadingRenderer
+					path={[...path, 'children', sectionIndex, 'heading']}
+					{refs}
+					{onUnmount}
+					{...createHeadingNavProps(child, node, sectionIndex, document)}
+					overrides={{
+						class: 'prose-h1:text-xl'
+					}}
+					onClickReadMode={() => {
+						// toggle the state in the default view, not change it to the default view. Change the state in the default view.
+						const defaultView = node.children[sectionIndex].view.find(
+							(v) => v.type === 'collection/section/default'
+						);
+						if (defaultView) {
+							document.state.animateNextChange = true;
+							onUnmount();
+							defaultView.state = defaultView.state === 'expanded' ? 'summary' : 'expanded';
+						}
+						if (onHeadingClick) {
+							onHeadingClick(child);
+						}
+					}}
+				/>
+				{#each SummaryRenderers as { summaryChild, summaryIndex, Renderer }}
+					<Renderer
+						path={[...path, 'children', sectionIndex, 'summary', summaryIndex]}
+						{refs}
+						{onUnmount}
+						overrides={{
+							class: 'prose-p:text-xs prose-p:text-gray-500'
+						}}
+						{...createSummaryNavProps(child, node, summaryChild.id, sectionIndex, document)}
+					/>
+				{/each}
+			</div>
+		</div>
+	{/each}
+
+	{#if document.state.mode !== 'read'}
+		<Chip
+			onclick={() => {
+				onUnmount();
+				addSection(node, node.children[0].heading.level);
+			}}
+			label="Add Section"
+		/>
+	{/if}
+</div>
+
+<style lang="postcss">
+	.card-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(var(--min-card-width), 1fr));
+		gap: var(--gap);
+	}
+
+	.card {
+		min-width: var(--min-card-width);
+	}
+</style>

--- a/src/lib/view/collection/section-container/Card/cardUtils.ts
+++ b/src/lib/view/collection/section-container/Card/cardUtils.ts
@@ -1,0 +1,65 @@
+import { sectionContainer, sectionContainerCardViewState } from '$lib/model/collection';
+import type { Refs } from '$lib/components/Document.svelte';
+import type { NavigationHandler } from '$lib/services/navigation/types';
+import type { Document } from '$lib/model/document';
+import type { z } from 'zod';
+import { addSection } from '$lib/actions/collection/section-container.svelte';
+
+// Define component types with navigation props
+export type HeadingComponentProps = {
+	path: (string | number)[];
+	refs: Refs;
+	onUnmount: () => void;
+	updateParent?: () => void;
+	getNextEditable?: NavigationHandler;
+	getPrevEditable?: NavigationHandler;
+	overrides?: {
+		class?: string;
+	};
+	onClickReadMode?: () => void;
+	documentNode?: Document;
+};
+
+export type ContentComponentProps = {
+	path: (string | number)[];
+	refs: Refs;
+	onUnmount: () => void;
+	overrides?: {
+		class?: string;
+	};
+	updateParent?: () => void;
+	onSplit?: (blocks: [string, string]) => void;
+	getNextEditable?: NavigationHandler;
+	getPrevEditable?: NavigationHandler;
+	documentNode?: Document;
+};
+
+export type SectionContainerType = z.infer<typeof sectionContainer>;
+export type SectionContainerViewStateType = z.infer<typeof sectionContainerCardViewState>;
+
+// Function to handle read mode toggle
+export function handleReadModeToggle(
+	sectionIndex: number,
+	node: SectionContainerType,
+	document: Document,
+	onUnmount: () => void
+) {
+	// toggle the state in the default view, not change it to the default view. Change the state in the default view.
+	const defaultView = node.children[sectionIndex].view.find(
+		(v) => v.type === 'collection/section/default'
+	);
+	if (defaultView) {
+		document.state.animateNextChange = true;
+		onUnmount();
+		defaultView.state = defaultView.state === 'expanded' ? 'summary' : 'expanded';
+	}
+}
+
+// Function to handle adding a section
+export function handleAddSection(
+	node: SectionContainerType,
+	onUnmount: () => void
+) {
+	onUnmount();
+	addSection(node, node.children[0].heading.level, "summary");
+}


### PR DESCRIPTION
now, there are two different flavors of cards, default and brick.

The reason why brick is added is that default takes up a lot of space, simply because the default view of cards is vertical by nature. This makes it bulky, and the image is bigger than it is supposed to be. This might be okay if we want the image to be the star of the show, but not if the image is supplementary.

<img width="501" alt="Screenshot 2025-04-16 at 19 25 56" src="https://github.com/user-attachments/assets/3dbfbd88-bd95-4e74-b269-9232305ec1fa" />

Brick view is horizontal:

<img width="541" alt="Screenshot 2025-04-16 at 19 27 11" src="https://github.com/user-attachments/assets/637dd900-d082-43f0-a3f0-401b7a5660ac" />
