### PR TITLE
collapse all sections, expand all sections for card view

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,8 @@ There is an issue where if you are in the editor mode, and you go from read to c
 When you press backspace at the start of a paragraph, cursor is just gone, not transfered. Should be transferred to previous paragraph, and the point where the two paragraphs are joined.
 
 There is a bit of jump in the summary when you go from card, and you click a heading, to default section container view, or vice versa. This issue only shows up when the card is in the third hierarchy level, and beyond, strangely enough.
+
+The editor, on press of heading, doesn't always create a content paragraph. I am not fully sure if it's the reason, but I encountered this when in the customize mode, the view was card. But I tried to make sure that it wasn't because the section was in summary mode that it failed. One followup could be testing if we could add parargaphs when the view of the section container is card.
+
+
+when the bricks is rendered as active section in a sidebar, not expected because it doesn't wrap. i think this is because I am using screen as breakpoint. Maybe should instead use min-width or something attached to the component instead of the screen size.

--- a/src/lib/view/collection/section-container/Card/Brick.svelte
+++ b/src/lib/view/collection/section-container/Card/Brick.svelte
@@ -16,7 +16,7 @@
 	import type { NavigationHandler } from '$lib/services/navigation/types';
 	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
 	import Chip from '$lib/components/Chip.svelte';
-	import { handleReadModeToggle, handleAddSection, type HeadingComponentProps, type ContentComponentProps, type SectionContainerType, type SectionContainerViewStateType } from './cardUtils';
+	import { handleAddSection, type HeadingComponentProps, type ContentComponentProps, type SectionContainerType, type SectionContainerViewStateType, expandAllSections } from './cardUtils';
 
 	// Custom action to bind an element to refs with a specific ID
 	function bindToRefs(element: HTMLElement, id: string) {
@@ -97,7 +97,7 @@
 					overrides={{
 						class: 'prose-h1:text-xl'
 					}}
-					onClickReadMode={() => handleReadModeToggle(sectionIndex, node, document, onUnmount)}
+					onClickReadMode={() => expandAllSections(node, document, onUnmount)}
 				/>
 				<div>
 					{#each SummaryRenderers as { summaryChild, summaryIndex, Renderer }}

--- a/src/lib/view/collection/section-container/Card/Card.svelte
+++ b/src/lib/view/collection/section-container/Card/Card.svelte
@@ -13,6 +13,7 @@
 	import Default from './Default.svelte';
 	import Brick from './Brick.svelte';
 	import type { z } from 'zod';
+	import { collapseAllSections } from './cardUtils';
 
 	let {
 		path,
@@ -61,7 +62,16 @@
 	return defaultView?.state === 'summary';
 })}
 	<div class="card-container" onmouseenter={showCardControls} onmouseleave={hideCardControls}>
-		<DefaultView {path} {refs} {onUnmount}/>
+		<DefaultView 
+			{path} 
+			{refs} 
+			{onUnmount} 
+			onHeadingClick={(section) => {
+				// When a heading is clicked in the default view that was shown from card view,
+				// collapse all sections to go back to card view
+				collapseAllSections(node, document, onUnmount);
+			}} 
+		/>
 	</div>
 {:else}
 	<div class="card-container" onmouseenter={showCardControls} onmouseleave={hideCardControls}>

--- a/src/lib/view/collection/section-container/Card/Default.svelte
+++ b/src/lib/view/collection/section-container/Card/Default.svelte
@@ -12,18 +12,18 @@
 	import { getContext } from 'svelte';
 	import type { Document } from '$lib/model/document';
 	import { addSection } from '$lib/actions/collection/section-container.svelte';
-	import { createHeadingNavProps, createSummaryNavProps } from './navigation';
-	import type { NavigationHandler } from '$lib/services/navigation/types';
-	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
-	import Chip from '$lib/components/Chip.svelte';
-	import {
-		handleReadModeToggle,
-		handleAddSection,
-		type HeadingComponentProps,
-		type ContentComponentProps,
-		type SectionContainerType,
-		type SectionContainerViewStateType
-	} from './cardUtils';
+import { createHeadingNavProps, createSummaryNavProps } from './navigation';
+import type { NavigationHandler } from '$lib/services/navigation/types';
+import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
+import Chip from '$lib/components/Chip.svelte';
+import {
+	expandAllSections,
+	handleAddSection,
+	type HeadingComponentProps,
+	type ContentComponentProps,
+	type SectionContainerType,
+	type SectionContainerViewStateType
+} from './cardUtils';
 
 	// Custom action to bind an element to refs with a specific ID
 	function bindToRefs(element: HTMLElement, id: string) {
@@ -104,7 +104,7 @@
 					overrides={{
 						class: 'prose-h1:text-xl'
 					}}
-					onClickReadMode={() => handleReadModeToggle(sectionIndex, node, document, onUnmount)}
+					onClickReadMode={() => expandAllSections(node, document, onUnmount)}
 				/>
 				{#each SummaryRenderers as { summaryChild, summaryIndex, Renderer }}
 					<Renderer

--- a/src/lib/view/collection/section-container/Card/cardUtils.ts
+++ b/src/lib/view/collection/section-container/Card/cardUtils.ts
@@ -37,22 +37,40 @@ export type ContentComponentProps = {
 export type SectionContainerType = z.infer<typeof sectionContainer>;
 export type SectionContainerViewStateType = z.infer<typeof sectionContainerCardViewState>;
 
-// Function to handle read mode toggle
-export function handleReadModeToggle(
-	sectionIndex: number,
+// Function to expand all sections in a section container
+export function expandAllSections(
 	node: SectionContainerType,
 	document: Document,
 	onUnmount: () => void
 ) {
-	// toggle the state in the default view, not change it to the default view. Change the state in the default view.
-	const defaultView = node.children[sectionIndex].view.find(
-		(v) => v.type === 'collection/section/default'
-	);
-	if (defaultView) {
-		document.state.animateNextChange = true;
-		onUnmount();
-		defaultView.state = defaultView.state === 'expanded' ? 'summary' : 'expanded';
-	}
+	document.state.animateNextChange = true;
+	onUnmount();
+	
+	// Set all sections to expanded state
+	node.children.forEach(child => {
+		const defaultView = child.view.find(v => v.type === 'collection/section/default');
+		if (defaultView) {
+			defaultView.state = 'expanded';
+		}
+	});
+}
+
+// Function to collapse all sections in a section container
+export function collapseAllSections(
+	node: SectionContainerType,
+	document: Document,
+	onUnmount: () => void
+) {
+	document.state.animateNextChange = true;
+	onUnmount();
+	
+	// Set all sections to summary state
+	node.children.forEach(child => {
+		const defaultView = child.view.find(v => v.type === 'collection/section/default');
+		if (defaultView) {
+			defaultView.state = 'summary';
+		}
+	});
 }
 
 // Function to handle adding a section

--- a/src/lib/view/collection/section/default/Default.svelte
+++ b/src/lib/view/collection/section/default/Default.svelte
@@ -152,6 +152,7 @@
 
 						if (onHeadingClick) {
 							onHeadingClick(node);
+                            return
 						}
 
 						if ((node.view[viewStateIndex] as ViewState).state === 'expanded') {


### PR DESCRIPTION
makes interaction with the card view more natural, when you click on a card, it expands all cards, when you collapse a section in the default view mode of the card view, you collapse everything.

The reason why is because there is less steps necessary to collapse a section back to card view.