### PR TITLE
attempt to have option of section summary being always available

### DIFF
--- a/src/lib/components/Document.svelte
+++ b/src/lib/components/Document.svelte
@@ -23,7 +23,7 @@
 	let writerContext = $state({ showSummary: true });
 
 	let { node: document }: { node: Document } = $props();
-    const node = $state(document);
+	const node = $state(document);
 	const documentManipulator = createDocumentManipulator(node);
 	setContext('document', node);
 	setContext('documentManipulator', documentManipulator);
@@ -48,14 +48,14 @@
 		// 	.filter((ref) => ref.element)
 		// 	.map((ref) => ref.element);
 		// flipState = Flip.getState(elements, {
-        //     props: "fontSize,lineHeight"
-        // });
+		//     props: "fontSize,lineHeight"
+		// });
 	};
 
 	// $effect(() => {
 	// 	if (flipState !== null && node.state.animateNextChange) {
 	// 		const elements = Object.values(refs).map(ref => ref.element);
-			
+
 	// 		Flip.from(flipState as Flip.FlipState, {
 	// 			targets: elements,
 	// 			duration: 0.2,

--- a/src/lib/migrations/collection/section.ts
+++ b/src/lib/migrations/collection/section.ts
@@ -1,0 +1,37 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Migration } from '../types';
+
+export const addSectionVariationMigration: Migration = {
+  id: 'section-add-variation-field',
+  description: 'Adds the variation field to section default view state',
+  apply: (node: any) => {
+    if (node.type !== 'section') return false;
+    
+    let modified = false;
+    
+    // Find the default view in the view array
+    const defaultViewIndex = node.view.findIndex((v: any) => v.type === 'collection/section/default');
+    if (defaultViewIndex >= 0) {
+      const defaultView = node.view[defaultViewIndex];
+      
+      // Check if state is a string enum value (old format)
+      if (typeof defaultView.state === 'string' && 
+          (defaultView.state === 'expanded' || defaultView.state === 'summary')) {
+        // Convert string state to object with state and variation properties
+        const currentState = defaultView.state;
+        defaultView.state = {
+          state: currentState,
+          variation: 'default'
+        };
+        modified = true;
+      }
+    }
+    
+    return modified;
+  }
+};
+
+export const sectionMigrations: Migration[] = [
+  addSectionVariationMigration,
+  // Add other section migrations here as needed
+];

--- a/src/lib/migrations/index.ts
+++ b/src/lib/migrations/index.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Migration, MigrationResult } from './types';
+import { sectionMigrations } from './collection/section';
+
+// Combine all migrations
+export const allMigrations: Migration[] = [
+  ...sectionMigrations,
+  // Add other migrations here
+];
+
+// Apply all applicable migrations to a node
+export function applyMigrations(node: any): MigrationResult[] {
+  const results: MigrationResult[] = [];
+  
+  if (!node) return results;
+  
+  // Apply migrations based on node type
+  const applicableMigrations = getMigrationsForNode(node);
+  
+  for (const migration of applicableMigrations) {
+    const applied = migration.apply(node);
+    if (applied) {
+      results.push({
+        applied,
+        migrationId: migration.id
+      });
+    }
+  }
+  
+  // Recursively apply migrations to children if they exist
+  if (node.children && Array.isArray(node.children)) {
+    for (const child of node.children) {
+      results.push(...applyMigrations(child));
+    }
+  }
+  
+  // Also check summary if it exists
+  if (node.summary && Array.isArray(node.summary)) {
+    for (const item of node.summary) {
+      results.push(...applyMigrations(item));
+    }
+  }
+  
+  return results;
+}
+
+// Get migrations applicable to a specific node type
+function getMigrationsForNode(node: any): Migration[] {
+  if (!node || !node.type) return [];
+  
+  switch (node.type) {
+    case 'section':
+      return sectionMigrations;
+    // Add other node types here
+    default:
+      return [];
+  }
+}

--- a/src/lib/migrations/types.ts
+++ b/src/lib/migrations/types.ts
@@ -1,0 +1,11 @@
+export interface Migration {
+  id: string;          // Unique identifier for the migration
+  description: string; // Description of what the migration does
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  apply: (node: any) => boolean; // Function to apply migration, returns true if changes were made
+}
+
+export interface MigrationResult {
+  applied: boolean;    // Whether the migration was applied
+  migrationId: string; // ID of the migration that was applied
+}

--- a/src/lib/model/collection.ts
+++ b/src/lib/model/collection.ts
@@ -24,11 +24,17 @@ const collectionBase = z.object({
 	view: z.string()
 });
 
+// Define a new type for the section default view state with variation
+export const sectionDefaultViewState = z.object({
+	state: z.enum(['expanded', 'summary']),
+	variation: z.enum(['default', 'summary-visible-on-expand'])
+});
+
 // collection/section/view
 const sectionView = z.tuple([
 	z.object({
 		type: z.literal('collection/section/default'),
-		state: z.enum(['expanded', 'summary'])
+		state: sectionDefaultViewState
 	}),
 	z.object({
 		type: z.literal('collection/section/static')

--- a/src/lib/view/collection/section-container/Card/Card.svelte
+++ b/src/lib/view/collection/section-container/Card/Card.svelte
@@ -9,7 +9,7 @@
 	import type { Document } from '$lib/model/document';
 	import Controls from './Controls.svelte';
 	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
-    import DefaultView from "$lib/view/collection/section-container/Default/Default.svelte"
+	import DefaultView from '$lib/view/collection/section-container/Default/Default.svelte';
 	import Default from './Default.svelte';
 	import Brick from './Brick.svelte';
 	import type { z } from 'zod';
@@ -44,7 +44,6 @@
 		isCardHovered = false;
 	}
 
-
 	// Get the current variation from the state
 	function getVariation() {
 		const currentView = view.find((v) => v.type === activeView);
@@ -53,24 +52,24 @@
 		}
 		return 'default';
 	}
-	
+
 	let variation = $derived(getVariation());
 </script>
 
 {#if !node.children.every((child) => {
 	const defaultView = child.view.find((v) => v.type === 'collection/section/default');
-	return defaultView?.state === 'summary';
+	return defaultView?.state.state === 'summary';
 })}
 	<div class="card-container" onmouseenter={showCardControls} onmouseleave={hideCardControls}>
-		<DefaultView 
-			{path} 
-			{refs} 
-			{onUnmount} 
+		<DefaultView
+			{path}
+			{refs}
+			{onUnmount}
 			onHeadingClick={(section) => {
 				// When a heading is clicked in the default view that was shown from card view,
 				// collapse all sections to go back to card view
 				collapseAllSections(node, document, onUnmount);
-			}} 
+			}}
 		/>
 	</div>
 {:else}
@@ -80,7 +79,7 @@
 		{/if}
 
 		{#if variation === 'brick'}
-			<Brick {path} {refs} {onUnmount}/>
+			<Brick {path} {refs} {onUnmount} />
 		{:else}
 			<Default {path} {refs} {onUnmount} />
 		{/if}

--- a/src/lib/view/collection/section-container/Card/cardUtils.ts
+++ b/src/lib/view/collection/section-container/Card/cardUtils.ts
@@ -45,12 +45,12 @@ export function expandAllSections(
 ) {
 	document.state.animateNextChange = true;
 	onUnmount();
-	
+
 	// Set all sections to expanded state
-	node.children.forEach(child => {
-		const defaultView = child.view.find(v => v.type === 'collection/section/default');
+	node.children.forEach((child) => {
+		const defaultView = child.view.find((v) => v.type === 'collection/section/default');
 		if (defaultView) {
-			defaultView.state = 'expanded';
+			defaultView.state.state = 'expanded';
 		}
 	});
 }
@@ -63,21 +63,18 @@ export function collapseAllSections(
 ) {
 	document.state.animateNextChange = true;
 	onUnmount();
-	
+
 	// Set all sections to summary state
-	node.children.forEach(child => {
-		const defaultView = child.view.find(v => v.type === 'collection/section/default');
+	node.children.forEach((child) => {
+		const defaultView = child.view.find((v) => v.type === 'collection/section/default');
 		if (defaultView) {
-			defaultView.state = 'summary';
+			defaultView.state.state = 'summary';
 		}
 	});
 }
 
 // Function to handle adding a section
-export function handleAddSection(
-	node: SectionContainerType,
-	onUnmount: () => void
-) {
+export function handleAddSection(node: SectionContainerType, onUnmount: () => void) {
 	onUnmount();
-	addSection(node, node.children[0].heading.level, "summary");
+	addSection(node, node.children[0].heading.level, 'summary');
 }

--- a/src/lib/view/collection/section/default/control/DefaultControl.svelte
+++ b/src/lib/view/collection/section/default/control/DefaultControl.svelte
@@ -3,13 +3,18 @@
 	import SummaryIcon from './SummaryIcon.svelte';
 	import { getContext } from 'svelte';
 	import type { Document } from '$lib/model/document';
+	import type { sectionDefaultViewState } from '$lib/model/collection';
+	import type { z } from 'zod';
+	
+	type ViewState = z.infer<typeof sectionDefaultViewState>;
+	
 	let {
 		controlElement = $bindable(),
 		viewState,
 		onUnmount
 	}: {
 		controlElement: HTMLDivElement;
-		viewState: { state: 'expanded' | 'summary' };
+		viewState: ViewState;
 		onUnmount: () => void;
 	} = $props();
 


### PR DESCRIPTION
It is a failed attempt hahahah.

There are two things going on here. 

First, I tried to add a migration logic. What this would help for is if we change the schema of the document, it automatically updates a fetched document that would be displayed to conform to the new schema.

Second, is the real update to the document schema, where there is a new field in the view state of default section view, variation.

Third, make existing logic, (that uses the expansion state) still work, when the schema has changed.

Fourth, add the ability to actually show section summary in the section when expanded.

I think it failed cause I was doing it all at once, and I got confused where the mistake was, so redoing it one by one.