### PR TITLE
Ability to make summary always visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,5 @@ The editor, on press of heading, doesn't always create a content paragraph. I am
 when the bricks is rendered as active section in a sidebar, not expected because it doesn't wrap. i think this is because I am using screen as breakpoint. Maybe should instead use min-width or something attached to the component instead of the screen size.
 
 documents are mysteriously disappearing from the database, like text cinema's doc, aak.
+
+when the editor initially loads, the summary select dropdown has empty value, not populated properly.

--- a/src/lib/view/collection/section-container/Default/Controls.svelte
+++ b/src/lib/view/collection/section-container/Default/Controls.svelte
@@ -22,12 +22,40 @@
 	let floatingElement: HTMLDivElement;
 	let referenceElement: HTMLDivElement;
 
+	// Reactive variable to track the current variation across all child sections
+	let currentVariation = $derived(() => {
+		// If any section has summary-always, return that
+		for (const child of node.children) {
+			const defaultView = child.view.find((view) => view.type === 'collection/section/default');
+			if (defaultView && defaultView.state.variation === 'summary-always') {
+				return 'summary-always';
+			}
+		}
+		return 'default';
+	});
+
 	function showControls() {
 		isHovered = true;
 	}
 
 	function hideControls() {
 		isHovered = false;
+	}
+	
+	// Update all child sections' variation
+	function updateChildrenVariation(event: Event) {
+		const select = event.target as HTMLSelectElement;
+		const newVariation = select.value as 'default' | 'summary-always';
+		
+		onUnmount();
+		
+		// Update all child sections
+		node.children.forEach((child) => {
+			const defaultView = child.view.find((view) => view.type === 'collection/section/default');
+			if (defaultView) {
+				defaultView.state.variation = newVariation;
+			}
+		});
 	}
 
 	function switchToTabs() {
@@ -76,7 +104,18 @@
 	<button class="rounded-md bg-blue-500 p-2 text-white" onclick={switchToTableOfContents}>
 		toc
 	</button>
-	<button class="rounded-md bg-blue-500 p-2 text-white" onclick={switchToSidebar}> sidebar </button>
+	<button class="mb-1 rounded-md bg-blue-500 p-2 text-white" onclick={switchToSidebar}> sidebar </button>
+	
+	<div class="flex flex-col">
+		<label for="variation-select" class="text-sm text-gray-700">Summary:</label>
+		<select 
+			value={currentVariation}
+			onchange={updateChildrenVariation}
+		>
+			<option value="default">Default</option>
+			<option value="summary-always">Always Show</option>
+		</select>
+	</div>
 </div>
 
 <div bind:this={referenceElement} class="reference-element w-full"></div>

--- a/src/lib/view/collection/section/default/Default.svelte
+++ b/src/lib/view/collection/section/default/Default.svelte
@@ -213,6 +213,21 @@
 
 	<div bind:this={contentElement} class="flex flex-col gap-7">
 		{#if (node.view[viewStateIndex] as ViewState).state.state === 'expanded'}
+			{#if (node.view[viewStateIndex] as ViewState).state.variation === 'summary-always' && SummaryRenderers.length > 0}
+				<!-- Show summary first when variation is summary-always -->
+					{#each SummaryRenderers as { Renderer }, i (node.summary[i].last_modified + node.summary[i].id)}
+						<Renderer
+							path={[...path, 'summary', i]}
+							{refs}
+							overrides={{ class: 'prose-p:text-gray-500' }}
+							onSplit={(newBlocks) => {
+								splitParagraph(node, 'summary', newBlocks, document, i);
+							}}
+							{onUnmount}
+						/>
+					{/each}
+			{/if}
+			
 			{console.log('children renderers length in section: ', ChildrenRenderers.length)}
 			<!-- should work without the key, but not working -->
 			{#each ChildrenRenderers as { Renderer }, i (node.children[i].last_modified + node.children[i].id)}


### PR DESCRIPTION
<img width="1338" alt="Screenshot 2025-04-19 at 01 22 08" src="https://github.com/user-attachments/assets/b1dd914d-3a88-4719-8538-b35eff604545" />

Section is expanded (it is not being collapsed), but the summary is visible. Before, this was not possible.

The control for this is in the section container level in the customize mode of the editor:

<img width="404" alt="Screenshot 2025-04-19 at 01 23 11" src="https://github.com/user-attachments/assets/411809c8-490c-4672-8002-61af8b48cc01" />
