### PR TITLE
make heading stay at the same place on expand/collapse for card

### DIFF
--- a/src/lib/view/collection/section-container/Card/Brick.svelte
+++ b/src/lib/view/collection/section-container/Card/Brick.svelte
@@ -46,7 +46,7 @@
 	}: {
 		path: (string | number)[];
 		refs: Refs;
-		onUnmount: () => void;
+		onUnmount: (elementToPin?: string | null) => void;
 	} = $props();
 
 	const node = documentManipulator.getByPath(path) as SectionContainerType;
@@ -97,7 +97,12 @@
 					overrides={{
 						class: 'prose-h1:text-base md:prose-h1:text-xl'
 					}}
-					onClickReadMode={() => expandAllSections(node, document, onUnmount)}
+					onClickReadMode={() => {
+						// Pass the heading ID to onUnmount using a closure
+						expandAllSections(node, document, () => {
+                            console.log("onUnmounting with id: " + child.heading.id)
+                            onUnmount(child.heading.id)});
+					}}
 				/>
 				<div>
 					{#each SummaryRenderers as { summaryChild, summaryIndex, Renderer }}

--- a/src/lib/view/collection/section-container/Card/Card.svelte
+++ b/src/lib/view/collection/section-container/Card/Card.svelte
@@ -22,7 +22,7 @@
 	}: {
 		path: (string | number)[];
 		refs: Refs;
-		onUnmount: () => void;
+		onUnmount: (elementToPin?: string | null) => void;
 	} = $props();
 
 	const document = getContext('document') as Document;

--- a/src/lib/view/collection/section-container/Card/Controls.svelte
+++ b/src/lib/view/collection/section-container/Card/Controls.svelte
@@ -12,7 +12,7 @@
 		isCardHovered
 	}: {
 		path: (string | number)[];
-		onUnmount: () => void;
+		onUnmount: (elementToPin?: string | null) => void;
 		isCardHovered: boolean;
 	} = $props();
 

--- a/src/lib/view/collection/section-container/Card/Default.svelte
+++ b/src/lib/view/collection/section-container/Card/Default.svelte
@@ -12,27 +12,27 @@
 	import { getContext } from 'svelte';
 	import type { Document } from '$lib/model/document';
 	import { addSection } from '$lib/actions/collection/section-container.svelte';
-import { createHeadingNavProps, createSummaryNavProps } from './navigation';
-import type { NavigationHandler } from '$lib/services/navigation/types';
-import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
-import Chip from '$lib/components/Chip.svelte';
-import {
-	expandAllSections,
-	handleAddSection,
-	type HeadingComponentProps,
-	type ContentComponentProps,
-	type SectionContainerType,
-	type SectionContainerViewStateType
-} from './cardUtils';
+	import { createHeadingNavProps, createSummaryNavProps } from './navigation';
+	import type { NavigationHandler } from '$lib/services/navigation/types';
+	import type { DocumentManipulator } from '$lib/documentManipulator.svelte';
+	import Chip from '$lib/components/Chip.svelte';
+	import {
+		expandAllSections,
+		handleAddSection,
+		type HeadingComponentProps,
+		type ContentComponentProps,
+		type SectionContainerType,
+		type SectionContainerViewStateType
+	} from './cardUtils';
 
 	// Custom action to bind an element to refs with a specific ID
 	function bindToRefs(element: HTMLElement, id: string) {
 		// Set the data-flip-id attribute
 		element.setAttribute('data-flip-id', id);
-		
+
 		// Add the element to the refs object
 		refs[id] = { element };
-		
+
 		// Return a cleanup function
 		return {
 			destroy() {
@@ -52,7 +52,7 @@ import {
 	}: {
 		path: (string | number)[];
 		refs: Refs;
-		onUnmount: () => void;
+		onUnmount: (elementToPin?: string | null) => void;
 	} = $props();
 
 	const node = documentManipulator.getByPath(path) as SectionContainerType;
@@ -76,7 +76,6 @@ import {
 	);
 
 	let someHasImage = $derived(children.some((child) => child.image));
-
 
 	// Minimum width for cards
 	const minCardWidth = 250;
@@ -104,7 +103,10 @@ import {
 					overrides={{
 						class: 'prose-h1:text-md md:prose-h1:text-xl'
 					}}
-					onClickReadMode={() => expandAllSections(node, document, onUnmount)}
+					onClickReadMode={() => {
+						// Pass the heading ID to onUnmount using a closure
+						expandAllSections(node, document, () => onUnmount(child.heading.id));
+					}}
 				/>
 				{#each SummaryRenderers as { summaryChild, summaryIndex, Renderer }}
 					<Renderer
@@ -130,7 +132,7 @@ import {
 	.card-grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(var(--min-card-width), 1fr));
-        gap: 16px;
+		gap: 16px;
 	}
 
 	.card {

--- a/src/lib/view/collection/section-container/Card/cardUtils.ts
+++ b/src/lib/view/collection/section-container/Card/cardUtils.ts
@@ -9,7 +9,7 @@ import { addSection } from '$lib/actions/collection/section-container.svelte';
 export type HeadingComponentProps = {
 	path: (string | number)[];
 	refs: Refs;
-	onUnmount: () => void;
+	onUnmount: (elementToPin?: string | null) => void;
 	updateParent?: () => void;
 	getNextEditable?: NavigationHandler;
 	getPrevEditable?: NavigationHandler;
@@ -23,7 +23,7 @@ export type HeadingComponentProps = {
 export type ContentComponentProps = {
 	path: (string | number)[];
 	refs: Refs;
-	onUnmount: () => void;
+	onUnmount: (elementToPin?: string | null) => void;
 	overrides?: {
 		class?: string;
 	};
@@ -41,14 +41,14 @@ export type SectionContainerViewStateType = z.infer<typeof sectionContainerCardV
 export function expandAllSections(
 	node: SectionContainerType,
 	document: Document,
-	onUnmount: () => void
+	onUnmount: (elementToPin?: string | null) => void
 ) {
 	document.state.animateNextChange = true;
 	onUnmount();
-	
+
 	// Set all sections to expanded state
-	node.children.forEach(child => {
-		const defaultView = child.view.find(v => v.type === 'collection/section/default');
+	node.children.forEach((child) => {
+		const defaultView = child.view.find((v) => v.type === 'collection/section/default');
 		if (defaultView) {
 			defaultView.state.state = 'expanded';
 		}
@@ -59,14 +59,14 @@ export function expandAllSections(
 export function collapseAllSections(
 	node: SectionContainerType,
 	document: Document,
-	onUnmount: () => void
+	onUnmount: (elementToPin?: string | null) => void
 ) {
 	document.state.animateNextChange = true;
 	onUnmount();
-	
+
 	// Set all sections to summary state
-	node.children.forEach(child => {
-		const defaultView = child.view.find(v => v.type === 'collection/section/default');
+	node.children.forEach((child) => {
+		const defaultView = child.view.find((v) => v.type === 'collection/section/default');
 		if (defaultView) {
 			defaultView.state.state = 'summary';
 		}
@@ -76,8 +76,8 @@ export function collapseAllSections(
 // Function to handle adding a section
 export function handleAddSection(
 	node: SectionContainerType,
-	onUnmount: () => void
+	onUnmount: (elementToPin?: string | null) => void
 ) {
 	onUnmount();
-	addSection(node, node.children[0].heading.level, "summary");
+	addSection(node, node.children[0].heading.level, 'summary');
 }

--- a/src/lib/view/collection/section-container/Default/Controls.svelte
+++ b/src/lib/view/collection/section-container/Default/Controls.svelte
@@ -10,7 +10,7 @@
 		isDefaultHovered
 	}: {
 		path: (string | number)[];
-		onUnmount: () => void;
+		onUnmount: (elementToPin?: string | null) => void;
 		isDefaultHovered: boolean;
 	} = $props();
 

--- a/src/lib/view/collection/section-container/Default/Default.svelte
+++ b/src/lib/view/collection/section-container/Default/Default.svelte
@@ -20,7 +20,7 @@
 	}: {
 		path: (string | number)[];
 		refs: Refs;
-		onUnmount: () => void;
+		onUnmount: (elementToPin?: string | null) => void;
 		onHeadingClick?: (section: Section) => void;
 	} = $props();
 
@@ -37,7 +37,7 @@
 			Renderer: registry[child.activeView as keyof typeof registry] as Component<{
 				path: (string | number)[];
 				refs: Refs;
-				onUnmount: () => void;
+				onUnmount: (elementToPin?: string | null) => void;
 				addSection: (section: Section) => void;
 				findPrecedingSection: (level: number) => Section | null;
 				findParentSection: () => Section | null;

--- a/src/lib/view/collection/section/default/Default.svelte
+++ b/src/lib/view/collection/section/default/Default.svelte
@@ -19,7 +19,7 @@
 	type Props = {
 		path: (string | number)[];
 		refs: Refs;
-		onUnmount: () => void;
+		onUnmount: (elementToPin?: string | null) => void;
 		overrides?: { heading?: boolean; accommodateControls?: boolean };
 		addSection: (newSection: Section) => void;
 		findPrecedingSection: (level: number) => Section | null;
@@ -152,7 +152,8 @@
 			<div bind:this={headingElement}>
 				<HeadingRenderer
 					onClickReadMode={() => {
-						onUnmount();
+						// Pass the heading ID to onUnmount before changing state
+						onUnmount(node.heading.id);
 						document.state.animateNextChange = false;
 
 						if (onHeadingClick) {

--- a/src/lib/view/collection/section/default/control/DefaultControl.svelte
+++ b/src/lib/view/collection/section/default/control/DefaultControl.svelte
@@ -15,7 +15,7 @@
 				variation: 'default' | 'summary-always'
 			} 
 		};
-		onUnmount: () => void;
+		onUnmount: (elementToPin?: string | null) => void;
 	} = $props();
 
 	let document = getContext('document') as Document;


### PR DESCRIPTION

https://github.com/user-attachments/assets/ebc6d8a0-6124-4b47-b14a-af17d29ea64a

you see how when we click on the heading in the card view, the section expanded, but the heading remains in the same place? This is the result of the current change. 

The purpose is so that people don't feel lost after they just clicked/tapped some heading.